### PR TITLE
Add authenticated conversations and item messaging flow

### DIFF
--- a/backend/src/app/routes/conversations.py
+++ b/backend/src/app/routes/conversations.py
@@ -1,9 +1,15 @@
 """
-NOTE: Current_user_id = 1 is still hardcoded everywhere
+Conversation routes.
+
+These routes use the logged-in user's JWT token to determine current_user_id.
 """
+
 from typing import Annotated
+
 from fastapi import APIRouter, Depends, Query
 from sqlalchemy.orm import Session
+
+from app.core.auth import get_current_user_id
 from app.core.db import get_db
 from app.schemas.conversation import (
     ConversationCreate,
@@ -19,52 +25,88 @@ import app.services.chat_service as chat_service
 api_router = APIRouter(prefix="/conversations", tags=["conversations"])
 
 DB = Annotated[Session, Depends(get_db)]
+CurrentUserId = Annotated[int, Depends(get_current_user_id)]
+
 
 # POST /conversations/
-@api_router.post("/", response_model=ConversationOut)       # response schema 
-def create_conversation(body: ConversationCreate, db: DB):  # input schema
-    """Create or find a conversation between two users."""
-    current_user_id = 1
-    return conversation_service.get_or_create_conversation(db, current_user_id, body.recipient_id)
+@api_router.post("/", response_model=ConversationOut)
+def create_conversation(
+    body: ConversationCreate,
+    db: DB,
+    current_user_id: CurrentUserId,
+):
+    """Create or find a conversation between the logged-in user and another user."""
+    return conversation_service.get_or_create_conversation(
+        db,
+        current_user_id,
+        body.recipient_id,
+    )
 
 
 # GET /conversations/
 @api_router.get("/", response_model=list[ConversationListItem])
-def list_conversations(db: DB, limit: int = Query(50, ge=1), offset: int = Query(0, ge=0)):
+def list_conversations(
+    db: DB,
+    current_user_id: CurrentUserId,
+    limit: int = Query(50, ge=1),
+    offset: int = Query(0, ge=0),
+):
     """List all active conversations for the logged-in user."""
-    current_user_id = 1
-    return conversation_service.list_conversations(db, current_user_id, limit, offset)
+    return conversation_service.list_conversations(
+        db,
+        current_user_id,
+        limit,
+        offset,
+    )
 
 
 # DELETE /conversations/{conversation_id}
 @api_router.delete("/{conversation_id}", response_model=SuccessResponse)
-def delete_conversation(conversation_id: int, db: DB):
-    """Delete a conversation and all its messages."""
-    current_user_id = 1
-    conversation_service.delete_conversation(db, current_user_id, conversation_id)
+def delete_conversation(
+    conversation_id: int,
+    db: DB,
+    current_user_id: CurrentUserId,
+):
+    """Delete a conversation if the logged-in user is a participant."""
+    conversation_service.delete_conversation(
+        db,
+        current_user_id,
+        conversation_id,
+    )
     return SuccessResponse()
 
 
-#--------- Routes for Messages ----------#
+# GET /conversations/{conversation_id}/messages
 @api_router.get("/{conversation_id}/messages", response_model=list[MessageListItem])
 def get_messages(
     conversation_id: int,
     db: DB,
+    current_user_id: CurrentUserId,
     limit: int = Query(50, ge=1),
     offset: int = Query(0, ge=0),
 ):
     """Retrieve message history for a conversation."""
-    current_user_id = 1
-    return chat_service.get_messages(db, current_user_id, conversation_id, limit, offset)
- 
- 
+    return chat_service.get_messages(
+        db,
+        current_user_id,
+        conversation_id,
+        limit,
+        offset,
+    )
+
+
 # POST /conversations/{conversation_id}/messages
 @api_router.post("/{conversation_id}/messages", response_model=MessageOut)
 def send_message(
     conversation_id: int,
     body: MessageCreate,
     db: DB,
+    current_user_id: CurrentUserId,
 ):
     """Send a new message in a conversation."""
-    current_user_id = 1
-    return chat_service.send_message(db, current_user_id, conversation_id, body.content)
+    return chat_service.send_message(
+        db,
+        current_user_id,
+        conversation_id,
+        body.content,
+    )

--- a/backend/src/app/routes/messages.py
+++ b/backend/src/app/routes/messages.py
@@ -1,22 +1,29 @@
 # backend/src/app/routes/messages.py
+
 from typing import Annotated
- 
+
 from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
- 
+
+from app.core.auth import get_current_user_id
 from app.core.db import get_db
 from app.schemas.conversation import SuccessResponse
 import app.services.chat_service as chat_service
- 
+
+
 api_router = APIRouter(prefix="/messages", tags=["messages"])
- 
+
 DB = Annotated[Session, Depends(get_db)]
- 
- 
+CurrentUserId = Annotated[int, Depends(get_current_user_id)]
+
+
 # DELETE /messages/{message_id}
 @api_router.delete("/{message_id}", response_model=SuccessResponse)
-def delete_message(message_id: int, db: DB):
-    """Delete a specific message."""
-    current_user_id = 1
+def delete_message(
+    message_id: int,
+    db: DB,
+    current_user_id: CurrentUserId,
+):
+    """Delete a specific message if the logged-in user is the sender."""
     chat_service.delete_message(db, current_user_id, message_id)
     return SuccessResponse()

--- a/backend/src/app/schemas/conversation.py
+++ b/backend/src/app/schemas/conversation.py
@@ -21,6 +21,7 @@ class ConversationOut(BaseModel):
 class ConversationListItem(BaseModel):
     id: int
     partner_id: int
+    partner_name: str
     last_message: str | None = None
 
     model_config = {"from_attributes": True}

--- a/backend/src/app/schemas/items.py
+++ b/backend/src/app/schemas/items.py
@@ -40,6 +40,7 @@ class ItemListItem(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
     id: int
+    user_id: int
     title: str
     description: str
     location: str

--- a/backend/src/app/services/conversation.py
+++ b/backend/src/app/services/conversation.py
@@ -9,9 +9,9 @@ from fastapi import HTTPException, status
 from sqlalchemy.orm import Session
 
 from app.repository.conversation_repository import ConversationRepository
-#from app.repository.message_repository import MessageRepository
+from app.repository.message_repository import MessageRepository
+from app.repository.user import UserRepository
 from app.schemas.conversation import ConversationListItem, ConversationOut
-
 
 def get_or_create_conversation(
     db: Session,
@@ -66,16 +66,26 @@ def list_conversations(
     """
     convos = ConversationRepository.list_for_user(db, current_user_id, limit, offset)
     result = []
+
     for convo in convos:
         partner_id = convo.user_id2 if convo.user_id1 == current_user_id else convo.user_id1
-        #last = MessageRepository.get_last_message(db, convo.id)                                Until Messages are working
-        result.append(ConversationListItem(
-            id=convo.id,
-            partner_id=partner_id,
-            #last_message=last.message_text if last else None,
-            last_message=None,                                                              #temporary until message backend works
-            #created_at=convo.created_at,
-        ))
+        partner = UserRepository.get_by_id(db, partner_id)
+        last = MessageRepository.get_last_message_for_conversation(db, convo.id)
+
+        if partner:
+            partner_name = f"{partner.first_name} {partner.last_name}".strip()
+        else:
+            partner_name = "Unknown User"
+
+        result.append(
+            ConversationListItem(
+                id=convo.id,
+                partner_id=partner_id,
+                partner_name=partner_name,
+                last_message=last.message_text if last else None,
+            )
+        )
+
     return result
 
 

--- a/frontend/src/app/create-account/page.tsx
+++ b/frontend/src/app/create-account/page.tsx
@@ -203,7 +203,7 @@ export default function CreateAccountPage() {
                     id="firstName"
                     name="firstName"
                     type="text"
-                    placeholder="Alan"
+                    placeholder="Your Name"
                     maxLength={15}
                     className="mt-2 w-full rounded-md border border-gray-300 px-4 py-3 text-gray-900 outline-none focus:border-[#C8102E] focus:ring-2 focus:ring-[#C8102E]/20"
                   />
@@ -221,7 +221,7 @@ export default function CreateAccountPage() {
                     id="lastName"
                     name="lastName"
                     type="text"
-                    placeholder="Alaniz"
+                    placeholder="Your Last Name"
                     maxLength={15}
                     className="mt-2 w-full rounded-md border border-gray-300 px-4 py-3 text-gray-900 outline-none focus:border-[#C8102E] focus:ring-2 focus:ring-[#C8102E]/20"
                   />

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -6,9 +6,9 @@ import Navbar from "@/components/navbar";
 import PostCard from "@/components/post-card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Inbox, PlusCircle, Search } from "lucide-react";
+import { PlusCircle, Search } from "lucide-react";
 import { apiFetch } from "@/lib/api";
-
+import ConversationPanel from "@/components/conversation-panel";
 
 type ItemPost = {
   id: number;
@@ -174,50 +174,7 @@ export default function Home() {
 
         {/* Right — Messages */}
         <aside>
-          <section className="min-h-[470px] rounded-xl border border-gray-200 bg-white p-5 shadow-sm">
-            <div className="flex items-center gap-3 border-b border-gray-100 pb-4">
-              <div className="flex h-10 w-10 items-center justify-center rounded-full bg-red-50 text-[#C8102E]">
-                <Inbox size={22} />
-              </div>
-
-              <div>
-                <h2 className="font-heading text-lg font-bold text-gray-900">
-                  Messages
-                </h2>
-                <p className="text-sm text-gray-500">
-                  Conversations about item recovery
-                </p>
-              </div>
-            </div>
-
-            <div className="flex min-h-[300px] items-center justify-center text-center">
-              <div>
-                <h3 className="font-heading text-xl font-bold text-gray-900">
-                  No conversations yet
-                </h3>
-
-                <p className="mt-3 max-w-xs text-sm leading-6 text-gray-600">
-                  When someone responds to your lost or found item post, the
-                  conversation will appear here.
-                </p>
-              </div>
-            </div>
-
-            <div className="border-t border-gray-100 pt-4">
-              <Input
-                disabled
-                placeholder="Select a conversation to send a message"
-                className="mb-3 bg-gray-50 text-sm"
-              />
-
-              <Button
-                disabled
-                className="w-full bg-[#C8102E] font-heading font-bold text-white disabled:cursor-not-allowed disabled:opacity-50"
-              >
-                Send
-              </Button>
-            </div>
-          </section>
+           <ConversationPanel />
         </aside>
       </div>
     </div>

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -2,13 +2,14 @@
 
 import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import Navbar from "@/components/navbar";
 import PostCard from "@/components/post-card";
+import ConversationPanel from "@/components/conversation-panel";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { PlusCircle, Search } from "lucide-react";
-import { apiFetch } from "@/lib/api";
-import ConversationPanel from "@/components/conversation-panel";
+import { apiFetch, createConversation, getApiErrorMessage } from "@/lib/api";
 
 type ItemPost = {
   id: number;
@@ -23,26 +24,34 @@ type ItemPost = {
 };
 
 export default function Home() {
+  const router = useRouter();
+
   const [posts, setPosts] = useState<ItemPost[]>([]);
   const [searchTerm, setSearchTerm] = useState("");
   const [selectedFilters, setSelectedFilters] = useState<string[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [errorMessage, setErrorMessage] = useState("");
 
-  useEffect(() => {
-  async function fetchPosts() {
-    try {
-      const data = await apiFetch<ItemPost[]>("/api/v1/home/");
-      setPosts(data);
-    } catch {
-      setErrorMessage("Could not connect to the backend server.");
-    } finally {
-      setIsLoading(false);
-    }
-  }
+  const [activeConversationId, setActiveConversationId] = useState<
+    number | null
+  >(null);
+  const [conversationRefreshKey, setConversationRefreshKey] = useState(0);
+  const [messageActionError, setMessageActionError] = useState("");
 
-  fetchPosts();
-}, []);
+  useEffect(() => {
+    async function fetchPosts() {
+      try {
+        const data = await apiFetch<ItemPost[]>("/api/v1/home/");
+        setPosts(data);
+      } catch {
+        setErrorMessage("Could not connect to the backend server.");
+      } finally {
+        setIsLoading(false);
+      }
+    }
+
+    fetchPosts();
+  }, []);
 
   const filteredPosts = useMemo(() => {
     return posts.filter((post) => {
@@ -71,6 +80,33 @@ export default function Home() {
         ? currentFilters.filter((currentFilter) => currentFilter !== filter)
         : [...currentFilters, filter],
     );
+  }
+
+  async function handleMessageAboutItem(ownerUserId: number) {
+    const token = localStorage.getItem("token");
+    const storedUserId = localStorage.getItem("userId");
+    const currentUserId = storedUserId ? Number(storedUserId) : null;
+
+    if (!token) {
+      router.push("/login?message=signin-required&redirect=/");
+      return;
+    }
+
+    if (currentUserId === ownerUserId) {
+      setMessageActionError("You cannot message yourself about your own post.");
+      return;
+    }
+
+    try {
+      setMessageActionError("");
+
+      const conversation = await createConversation(ownerUserId);
+
+      setActiveConversationId(conversation.id);
+      setConversationRefreshKey((currentKey) => currentKey + 1);
+    } catch (error) {
+      setMessageActionError(getApiErrorMessage(error));
+    }
   }
 
   return (
@@ -124,6 +160,12 @@ export default function Home() {
 
         {/* Center — Feed */}
         <main className="space-y-5">
+          {messageActionError && (
+            <section className="rounded-md border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-800">
+              {messageActionError}
+            </section>
+          )}
+
           {isLoading && (
             <section className="rounded-xl border border-gray-200 bg-white px-8 py-16 text-center shadow-sm">
               <p className="text-gray-600">Loading posts...</p>
@@ -141,7 +183,11 @@ export default function Home() {
           {!isLoading && !errorMessage && filteredPosts.length > 0 && (
             <>
               {filteredPosts.map((post) => (
-                <PostCard key={post.id} {...post} />
+                <PostCard
+                  key={post.id}
+                  {...post}
+                  onMessageAboutItem={handleMessageAboutItem}
+                />
               ))}
             </>
           )}
@@ -174,7 +220,10 @@ export default function Home() {
 
         {/* Right — Messages */}
         <aside>
-           <ConversationPanel />
+          <ConversationPanel
+            activeConversationId={activeConversationId}
+            refreshKey={conversationRefreshKey}
+          />
         </aside>
       </div>
     </div>

--- a/frontend/src/components/conversation-panel.tsx
+++ b/frontend/src/components/conversation-panel.tsx
@@ -13,6 +13,11 @@ import {
   sendConversationMessage,
 } from "@/lib/api";
 
+type ConversationPanelProps = {
+  activeConversationId?: number | null;
+  refreshKey?: number;
+};
+
 function getStoredUserId() {
   if (typeof window === "undefined") {
     return null;
@@ -29,7 +34,10 @@ function getStoredUserId() {
   return Number.isNaN(parsedUserId) ? null : parsedUserId;
 }
 
-export default function ConversationPanel() {
+export default function ConversationPanel({
+    activeConversationId = null,
+    refreshKey = 0,
+}: ConversationPanelProps) {
   const [currentUserId, setCurrentUserId] = useState<number | null>(null);
   const [isSignedIn, setIsSignedIn] = useState(false);
 
@@ -69,9 +77,20 @@ export default function ConversationPanel() {
 
       setConversations(data);
 
-      if (!selectedConversationId && data.length > 0) {
+      const shouldOpenActiveConversation =
+        activeConversationId &&
+        data.some((conversation) => conversation.id === activeConversationId);
+
+    if (shouldOpenActiveConversation) {
+        setSelectedConversationId(activeConversationId);
+    } else if (!selectedConversationId && data.length > 0) {
         setSelectedConversationId(data[0].id);
-      }
+    } else if (
+        selectedConversationId &&
+        !data.some((conversation) => conversation.id === selectedConversationId)
+    ) {
+        setSelectedConversationId(data[0]?.id ?? null);
+    }
     } catch (error) {
       setErrorMessage(getApiErrorMessage(error));
     } finally {
@@ -131,7 +150,7 @@ export default function ConversationPanel() {
 
   return () => window.clearTimeout(timeoutId);
   // eslint-disable-next-line react-hooks/exhaustive-deps
-}, []);
+}, [refreshKey]);
 
 useEffect(() => {
   const timeoutId = window.setTimeout(() => {

--- a/frontend/src/components/conversation-panel.tsx
+++ b/frontend/src/components/conversation-panel.tsx
@@ -1,0 +1,323 @@
+"use client";
+
+import { FormEvent, useEffect, useState } from "react";
+import Link from "next/link";
+import { Inbox, MessageCircle, Send } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  ConversationListItem,
+  MessageListItem,
+  getApiErrorMessage,
+  getConversationMessages,
+  getConversations,
+  sendConversationMessage,
+} from "@/lib/api";
+
+function getStoredUserId() {
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  const storedUserId = localStorage.getItem("userId");
+
+  if (!storedUserId) {
+    return null;
+  }
+
+  const parsedUserId = Number(storedUserId);
+
+  return Number.isNaN(parsedUserId) ? null : parsedUserId;
+}
+
+export default function ConversationPanel() {
+  const [currentUserId, setCurrentUserId] = useState<number | null>(null);
+  const [isSignedIn, setIsSignedIn] = useState(false);
+
+  const [conversations, setConversations] = useState<ConversationListItem[]>([]);
+  const [selectedConversationId, setSelectedConversationId] = useState<
+    number | null
+  >(null);
+  const [messages, setMessages] = useState<MessageListItem[]>([]);
+
+  const [newMessage, setNewMessage] = useState("");
+  const [isLoadingConversations, setIsLoadingConversations] = useState(true);
+  const [isLoadingMessages, setIsLoadingMessages] = useState(false);
+  const [isSending, setIsSending] = useState(false);
+  const [errorMessage, setErrorMessage] = useState("");
+
+  const selectedConversation = conversations.find(
+    (conversation) => conversation.id === selectedConversationId,
+  );
+
+  async function loadConversations() {
+    const token = localStorage.getItem("token");
+    const storedUserId = getStoredUserId();
+
+    setCurrentUserId(storedUserId);
+    setIsSignedIn(Boolean(token));
+
+    if (!token) {
+      setIsLoadingConversations(false);
+      return;
+    }
+
+    try {
+      setErrorMessage("");
+      setIsLoadingConversations(true);
+
+      const data = await getConversations();
+
+      setConversations(data);
+
+      if (!selectedConversationId && data.length > 0) {
+        setSelectedConversationId(data[0].id);
+      }
+    } catch (error) {
+      setErrorMessage(getApiErrorMessage(error));
+    } finally {
+      setIsLoadingConversations(false);
+    }
+  }
+
+  async function loadMessages(conversationId: number) {
+    try {
+      setErrorMessage("");
+      setIsLoadingMessages(true);
+
+      const data = await getConversationMessages(conversationId);
+
+      setMessages(data);
+    } catch (error) {
+      setErrorMessage(getApiErrorMessage(error));
+    } finally {
+      setIsLoadingMessages(false);
+    }
+  }
+
+  async function handleSendMessage(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+
+    const trimmedMessage = newMessage.trim();
+
+    if (!selectedConversationId || !trimmedMessage) {
+      return;
+    }
+
+    try {
+      setErrorMessage("");
+      setIsSending(true);
+
+      const sentMessage = await sendConversationMessage(
+        selectedConversationId,
+        trimmedMessage,
+      );
+
+      setMessages((currentMessages) => [...currentMessages, sentMessage]);
+      setNewMessage("");
+
+      const updatedConversations = await getConversations();
+      setConversations(updatedConversations);
+    } catch (error) {
+      setErrorMessage(getApiErrorMessage(error));
+    } finally {
+      setIsSending(false);
+    }
+  }
+
+  useEffect(() => {
+  const timeoutId = window.setTimeout(() => {
+    loadConversations();
+  }, 0);
+
+  return () => window.clearTimeout(timeoutId);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+}, []);
+
+useEffect(() => {
+  const timeoutId = window.setTimeout(() => {
+    if (selectedConversationId) {
+      loadMessages(selectedConversationId);
+    } else {
+      setMessages([]);
+    }
+  }, 0);
+
+  return () => window.clearTimeout(timeoutId);
+}, [selectedConversationId]);
+
+  return (
+    <section className="min-h-[470px] rounded-xl border border-gray-200 bg-white p-5 shadow-sm">
+      <div className="flex items-center gap-3 border-b border-gray-100 pb-4">
+        <div className="flex h-10 w-10 items-center justify-center rounded-full bg-red-50 text-[#C8102E]">
+          <Inbox size={22} />
+        </div>
+
+        <div>
+          <h2 className="font-heading text-lg font-bold text-gray-900">
+            Messages
+          </h2>
+          <p className="text-sm text-gray-500">
+            Conversations about item recovery
+          </p>
+        </div>
+      </div>
+
+      {!isSignedIn && !isLoadingConversations && (
+        <div className="flex min-h-[330px] items-center justify-center text-center">
+          <div>
+            <h3 className="font-heading text-xl font-bold text-gray-900">
+              Sign in to view messages
+            </h3>
+
+            <p className="mt-3 max-w-xs text-sm leading-6 text-gray-600">
+              You need an account to message other users about lost and found
+              items.
+            </p>
+
+            <Link href="/login?message=signin-required&redirect=/">
+              <Button className="mt-6 bg-[#C8102E] font-heading font-bold text-white hover:bg-[#a00d24]">
+                Sign In
+              </Button>
+            </Link>
+          </div>
+        </div>
+      )}
+
+      {isSignedIn && (
+        <>
+          {isLoadingConversations && (
+            <div className="flex min-h-[330px] items-center justify-center text-center">
+              <p className="text-sm text-gray-600">Loading conversations...</p>
+            </div>
+          )}
+
+          {!isLoadingConversations && errorMessage && (
+            <div className="mt-5 rounded-md bg-red-50 px-4 py-3 text-sm text-red-800">
+              {errorMessage}
+            </div>
+          )}
+
+          {!isLoadingConversations && conversations.length === 0 && (
+            <div className="flex min-h-[330px] items-center justify-center text-center">
+              <div>
+                <MessageCircle className="mx-auto h-10 w-10 text-[#C8102E]" />
+
+                <h3 className="mt-4 font-heading text-xl font-bold text-gray-900">
+                  No conversations yet
+                </h3>
+
+                <p className="mt-3 max-w-xs text-sm leading-6 text-gray-600">
+                  When you message someone about an item, the conversation will
+                  appear here.
+                </p>
+              </div>
+            </div>
+          )}
+
+          {!isLoadingConversations && conversations.length > 0 && (
+            <div className="mt-5 space-y-5">
+              <div className="max-h-44 space-y-2 overflow-y-auto pr-1">
+                {conversations.map((conversation) => {
+                  const isSelected = conversation.id === selectedConversationId;
+
+                  return (
+                    <button
+                      key={conversation.id}
+                      type="button"
+                      onClick={() => setSelectedConversationId(conversation.id)}
+                      className={`w-full rounded-lg border px-4 py-3 text-left transition ${
+                        isSelected
+                          ? "border-[#C8102E] bg-red-50"
+                          : "border-gray-200 bg-white hover:border-gray-300"
+                      }`}
+                    >
+                      <p className="font-heading text-sm font-bold text-gray-900">
+                        {conversation.partner_name}
+                      </p>
+
+                      <p className="mt-1 line-clamp-1 text-xs text-gray-500">
+                        {conversation.last_message || "No messages yet"}
+                      </p>
+                    </button>
+                  );
+                })}
+              </div>
+
+              <div className="rounded-lg border border-gray-200">
+                <div className="border-b border-gray-100 px-4 py-3">
+                  <h3 className="font-heading text-sm font-bold text-gray-900">
+                    {selectedConversation
+                      ? selectedConversation.partner_name
+                      : "Select a conversation"}
+                  </h3>
+                </div>
+
+                <div className="max-h-64 min-h-52 space-y-3 overflow-y-auto px-4 py-4">
+                  {isLoadingMessages && (
+                    <p className="text-center text-sm text-gray-500">
+                      Loading messages...
+                    </p>
+                  )}
+
+                  {!isLoadingMessages && messages.length === 0 && (
+                    <p className="text-center text-sm text-gray-500">
+                      No messages in this conversation yet.
+                    </p>
+                  )}
+
+                  {!isLoadingMessages &&
+                    messages.map((message) => {
+                      const isMine = message.sender_id === currentUserId;
+
+                      return (
+                        <div
+                          key={message.id}
+                          className={`flex ${
+                            isMine ? "justify-end" : "justify-start"
+                          }`}
+                        >
+                          <div
+                            className={`max-w-[85%] rounded-lg px-3 py-2 text-sm leading-5 ${
+                              isMine
+                                ? "bg-[#C8102E] text-white"
+                                : "bg-gray-100 text-gray-800"
+                            }`}
+                          >
+                            {message.message_text}
+                          </div>
+                        </div>
+                      );
+                    })}
+                </div>
+
+                <form
+                  onSubmit={handleSendMessage}
+                  className="border-t border-gray-100 p-3"
+                >
+                  <textarea
+                    value={newMessage}
+                    onChange={(event) => setNewMessage(event.target.value)}
+                    placeholder="Write a message..."
+                    rows={3}
+                    className="w-full resize-none rounded-md border border-gray-300 px-3 py-2 text-sm text-gray-900 outline-none focus:border-[#C8102E] focus:ring-2 focus:ring-[#C8102E]/20"
+                  />
+
+                  <Button
+                    type="submit"
+                    disabled={
+                      isSending || !selectedConversationId || !newMessage.trim()
+                    }
+                    className="mt-3 w-full bg-[#C8102E] font-heading font-bold text-white hover:bg-[#a00d24] disabled:cursor-not-allowed disabled:opacity-50"
+                  >
+                    <Send className="mr-2 h-4 w-4" />
+                    {isSending ? "Sending..." : "Send"}
+                  </Button>
+                </form>
+              </div>
+            </div>
+          )}
+        </>
+      )}
+    </section>
+  );
+}

--- a/frontend/src/components/post-card.tsx
+++ b/frontend/src/components/post-card.tsx
@@ -4,6 +4,7 @@ import { MapPin, MessageCircle } from "lucide-react";
 
 interface PostCardProps {
   id: number;
+  user_id: number;
   title: string;
   description: string;
   location: string;
@@ -11,6 +12,7 @@ interface PostCardProps {
   image_url: string | null;
   given_back: boolean;
   created_at: string;
+  onMessageAboutItem?: (ownerUserId: number) => void;
 }
 
 function formatDate(date: string) {
@@ -21,6 +23,7 @@ function formatDate(date: string) {
 }
 
 export default function PostCard({
+  user_id,
   title,
   description,
   location,
@@ -28,6 +31,7 @@ export default function PostCard({
   image_url,
   given_back,
   created_at,
+  onMessageAboutItem,
 }: PostCardProps) {
   const isLost = report_type === "lost";
 
@@ -78,7 +82,11 @@ export default function PostCard({
 
         <p className="mb-5 text-sm leading-6 text-gray-700">{description}</p>
 
-        <Button className="w-full bg-[#C8102E] font-heading font-bold text-white hover:bg-[#a00d24]">
+        <Button
+          type="button"
+          onClick={() => onMessageAboutItem?.(user_id)}
+          className="w-full bg-[#C8102E] font-heading font-bold text-white hover:bg-[#a00d24]"
+        >
           <MessageCircle className="mr-2 h-4 w-4" />
           Message About Item
         </Button>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -77,3 +77,86 @@ export async function apiFetch<T>(
 
   return data as T;
 }
+// Conversation API types
+
+export type ConversationListItem = {
+  id: number;
+  partner_id: number;
+  partner_name: string;
+  last_message: string | null;
+};
+
+export type ConversationOut = {
+  id: number;
+  participant_ids: number[];
+};
+
+export type MessageListItem = {
+  id: number;
+  sender_id: number;
+  message_text: string;
+  created_at: string;
+};
+
+export type MessageOut = {
+  id: number;
+  sender_id: number;
+  message_text: string;
+  is_read: boolean;
+  created_at: string;
+};
+
+export type SuccessResponse = {
+  success: boolean;
+};
+
+// Conversation API functions
+
+export function getConversations(limit = 50, offset = 0) {
+  return apiFetch<ConversationListItem[]>(
+    `/api/v1/conversations/?limit=${limit}&offset=${offset}`,
+  );
+}
+
+export function createConversation(recipientId: number) {
+  return apiFetch<ConversationOut>("/api/v1/conversations/", {
+    method: "POST",
+    body: JSON.stringify({
+      recipient_id: recipientId,
+    }),
+  });
+}
+
+export function deleteConversation(conversationId: number) {
+  return apiFetch<SuccessResponse>(`/api/v1/conversations/${conversationId}`, {
+    method: "DELETE",
+  });
+}
+
+export function getConversationMessages(
+  conversationId: number,
+  limit = 50,
+  offset = 0,
+) {
+  return apiFetch<MessageListItem[]>(
+    `/api/v1/conversations/${conversationId}/messages?limit=${limit}&offset=${offset}`,
+  );
+}
+
+export function sendConversationMessage(conversationId: number, content: string) {
+  return apiFetch<MessageOut>(
+    `/api/v1/conversations/${conversationId}/messages`,
+    {
+      method: "POST",
+      body: JSON.stringify({
+        content,
+      }),
+    },
+  );
+}
+
+export function deleteMessage(messageId: number) {
+  return apiFetch<SuccessResponse>(`/api/v1/messages/${messageId}`, {
+    method: "DELETE",
+  });
+}


### PR DESCRIPTION
## Summary

Implementation of the main conversation and messaging flow.

Users can now create or reuse conversations based on the logged in user, view message previews in the homepage message panel, open message history, send new messages and start a conversation directly from an item post. 

## Changes Made

- Updated conversation routes to use the authenticated JWT user instead of a hardcoded user ID.
- Added `user_id` to item list responses so the frontend knows which user owns each post.
- Updated conversation list responses to include:
  - `partner_id`
  - `partner_name`
  - `last_message`
- Added frontend conversation API functions in `api.ts`.
- Added a real `ConversationPanel` component.
- Replaced the static homepage Messages section with the new conversation panel.
- Connected the `Message About Item` button to create/open conversations.
- Added protection against messaging your own item post.
- Added signed out handling for the messages panel.