### PR TITLE
Improve account post management and home page UX

### DIFF
--- a/backend/src/app/repository/item_repository.py
+++ b/backend/src/app/repository/item_repository.py
@@ -88,7 +88,16 @@ class ItemRepository:
         db.commit()
         db.refresh(db_item)
         return db_item
+    
+    @staticmethod
+    def update_fields(db: Session, db_item: Item, fields: dict) -> Item:
+        for field_name, field_value in fields.items():
+            setattr(db_item, field_name, field_value)
 
+        db.commit()
+        db.refresh(db_item)
+        return db_item
+    
     @staticmethod
     def delete(db: Session, db_item: Item) -> None:
         db.delete(db_item)

--- a/backend/src/app/routes/items.py
+++ b/backend/src/app/routes/items.py
@@ -5,11 +5,12 @@ from sqlalchemy.orm import Session
 
 from app.core.auth import get_current_user_id
 from app.core.db import get_db
+
 from app.schemas.items import (
     ItemCreate,
     ItemListItem,
     ItemOut,
-    ItemStatusUpdate,
+    ItemUpdate,
     SuccessResponse,
 )
 import app.services.items as item_service
@@ -61,14 +62,14 @@ def create_item(
 
 # PUT /home/{item_id}
 @api_router.put("/{item_id}", response_model=SuccessResponse)
-def update_item_status(
+def update_item(
     item_id: int,
-    body: ItemStatusUpdate,
+    body: ItemUpdate,
     db: DB,
     current_user_id: CurrentUserId,
 ):
-    """Update item returned status."""
-    item_service.update_item_status(db, current_user_id, item_id, body)
+    """Update an item post if the logged-in user owns it."""
+    item_service.update_item(db, current_user_id, item_id, body)
     return SuccessResponse()
 
 

--- a/backend/src/app/routes/items.py
+++ b/backend/src/app/routes/items.py
@@ -30,6 +30,16 @@ def list_items(
     """List item posts in the database."""
     return item_service.list_items(db, limit, offset)
 
+# GET /home/my-posts
+@api_router.get("/my-posts", response_model=list[ItemListItem])
+def list_my_items(
+    db: DB,
+    current_user_id: CurrentUserId,
+    limit: int = Query(50, ge=1),
+    offset: int = Query(0, ge=0),
+):
+    """List item posts created by the logged-in user."""
+    return item_service.list_items_for_user(db, current_user_id, limit, offset)
 
 # GET /home/{item_id}
 @api_router.get("/{item_id}", response_model=ItemOut)

--- a/backend/src/app/schemas/items.py
+++ b/backend/src/app/schemas/items.py
@@ -5,6 +5,7 @@ from pydantic import BaseModel, ConfigDict, Field
 
 ReportType = Literal["lost", "found"]
 
+
 class SuccessResponse(BaseModel):
     success: bool = True
 
@@ -18,8 +19,13 @@ class ItemCreate(BaseModel):
     given_back: bool = False
 
 
-class ItemStatusUpdate(BaseModel):
-    given_back: bool
+class ItemUpdate(BaseModel):
+    title: str | None = Field(None, min_length=1, max_length=255)
+    description: str | None = Field(None, min_length=1)
+    location: str | None = Field(None, min_length=1, max_length=255)
+    report_type: ReportType | None = None
+    image_url: str | None = None
+    given_back: bool | None = None
 
 
 class ItemOut(BaseModel):

--- a/backend/src/app/schemas/user.py
+++ b/backend/src/app/schemas/user.py
@@ -13,6 +13,17 @@ class UserBase(BaseModel):
 
     email: EmailStr
 
+    @field_validator("email")
+    @classmethod
+    def email_must_be_sdsu(cls, email: EmailStr) -> EmailStr:
+        """Validate that the email belongs to SDSU."""
+        email_string = str(email).lower().strip()
+
+        if not email_string.endswith("@sdsu.edu"):
+            raise ValueError("Email must be a valid SDSU email address.")
+
+        return email_string
+
 
 class UserCreate(UserBase):
     """Schema for creating a new user."""
@@ -58,6 +69,20 @@ class UserUpdate(BaseModel):
     last_name: str | None = Field(None, min_length=1, max_length=15)
     email: EmailStr | None = None
 
+    @field_validator("email")
+    @classmethod
+    def email_must_be_sdsu(cls, email: EmailStr | None) -> EmailStr | None:
+        """Validate that updated email belongs to SDSU."""
+        if email is None:
+            return None
+
+        email_string = str(email).lower().strip()
+
+        if not email_string.endswith("@sdsu.edu"):
+            raise ValueError("Email must be a valid SDSU email address.")
+
+        return email_string
+    
     @field_validator("first_name", "last_name")
     @classmethod
     def name_must_not_be_blank(cls, name: str | None) -> str | None:

--- a/backend/src/app/services/items.py
+++ b/backend/src/app/services/items.py
@@ -8,6 +8,8 @@ from app.schemas.items import ItemCreate, ItemStatusUpdate
 def list_items(db: Session, limit: int, offset: int):
     return ItemRepository.list_all(db, limit, offset)
 
+def list_items_for_user(db: Session, current_user_id: int, limit: int, offset: int):
+    return ItemRepository.list_for_user(db, current_user_id, limit, offset)
 
 def get_item_by_id(db: Session, item_id: int):
     item = ItemRepository.get_by_id(db, item_id)

--- a/backend/src/app/services/items.py
+++ b/backend/src/app/services/items.py
@@ -2,8 +2,7 @@ from fastapi import HTTPException, status
 from sqlalchemy.orm import Session
 
 from app.repository.item_repository import ItemRepository
-from app.schemas.items import ItemCreate, ItemStatusUpdate
-
+from app.schemas.items import ItemCreate, ItemUpdate
 
 def list_items(db: Session, limit: int, offset: int):
     return ItemRepository.list_all(db, limit, offset)
@@ -36,11 +35,11 @@ def create_item(db: Session, body: ItemCreate, current_user_id: int):
     )
 
 
-def update_item_status(
+def update_item(
     db: Session,
     current_user_id: int,
     item_id: int,
-    body: ItemStatusUpdate,
+    body: ItemUpdate,
 ):
     item = ItemRepository.get_by_id(db, item_id)
 
@@ -56,7 +55,15 @@ def update_item_status(
             detail="Not allowed to update this item",
         )
 
-    return ItemRepository.update_status(db, item, body.given_back)
+    update_data = body.model_dump(exclude_unset=True)
+
+    if not update_data:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="No update fields were provided",
+        )
+
+    return ItemRepository.update_fields(db, item, update_data)
 
 
 def delete_item(db: Session, current_user_id: int, item_id: int):

--- a/frontend/src/app/about/page.tsx
+++ b/frontend/src/app/about/page.tsx
@@ -1,0 +1,159 @@
+import Link from "next/link";
+import Navbar from "@/components/navbar";
+import { Button } from "@/components/ui/button";
+import {
+  Search,
+  MessageCircle,
+  ShieldCheck,
+  ClipboardList,
+} from "lucide-react";
+
+const features = [
+  {
+    title: "Report lost items",
+    description:
+      "Create a clear post with the item name, description, location, status, and an image.",
+    icon: ClipboardList,
+  },
+  {
+    title: "Search campus posts",
+    description:
+      "Browse lost and found reports from the SDSU community and filter posts by item status.",
+    icon: Search,
+  },
+  {
+    title: "Message securely",
+    description:
+      "Start conversations with other users about item recovery without exposing personal contact details publicly.",
+    icon: MessageCircle,
+  },
+  {
+    title: "Track recovery status",
+    description:
+      "Posts can show whether an item is still active or has already been returned to its owner.",
+    icon: ShieldCheck,
+  },
+];
+
+export default function AboutPage() {
+  return (
+    <main className="min-h-screen bg-white text-black">
+      <Navbar />
+
+      <section className="bg-[#f4f4f4] px-6 py-20 md:px-16">
+        <div className="mx-auto max-w-5xl">
+          <p className="font-heading text-sm font-bold uppercase tracking-[0.22em] text-[#C8102E]">
+            About the project
+          </p>
+
+          <h1 className="mt-4 font-heading text-5xl font-semibold tracking-tight md:text-6xl">
+            SDSU Lost &amp; Found
+          </h1>
+
+          <div className="mt-6 h-[2px] w-28 bg-[#C8102E]" />
+
+          <p className="mt-8 max-w-3xl text-xl leading-8 text-gray-700">
+            SDSU Lost &amp; Found is a campus web application that helps
+            students, staff, and faculty report lost or found items, search
+            existing posts, and communicate with each other to return belongings
+            safely.
+          </p>
+        </div>
+      </section>
+
+      <section className="px-6 py-16 md:px-16">
+        <div className="mx-auto max-w-6xl">
+          <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-4">
+            {features.map((feature) => {
+              const Icon = feature.icon;
+
+              return (
+                <article
+                  key={feature.title}
+                  className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm"
+                >
+                  <div className="flex h-12 w-12 items-center justify-center rounded-full bg-red-50 text-[#C8102E]">
+                    <Icon size={24} />
+                  </div>
+
+                  <h2 className="mt-5 font-heading text-xl font-bold text-gray-900">
+                    {feature.title}
+                  </h2>
+
+                  <p className="mt-3 text-sm leading-6 text-gray-600">
+                    {feature.description}
+                  </p>
+                </article>
+              );
+            })}
+          </div>
+
+          <div className="mt-16 grid gap-10 lg:grid-cols-[1.1fr_0.9fr]">
+            <section>
+              <h2 className="font-heading text-3xl font-bold text-gray-900">
+                Why this app matters
+              </h2>
+
+              <p className="mt-5 text-lg leading-8 text-gray-700">
+                Lost items on campus are usually scattered across group chats,
+                front desks, classrooms, and word of mouth. This app centralizes
+                the process so users can post, search, and recover items from
+                one organized place.
+              </p>
+
+              <p className="mt-5 text-lg leading-8 text-gray-700">
+                The platform also adds accountability by connecting posts to
+                user accounts and keeping item communication inside the app
+                through the messaging system.
+              </p>
+            </section>
+
+            <aside className="rounded-xl border border-gray-200 bg-gray-50 p-8">
+              <h3 className="font-heading text-2xl font-bold text-gray-900">
+                Current project stack
+              </h3>
+
+              <ul className="mt-6 space-y-4 text-gray-700">
+                <li>
+                  <span className="font-semibold text-[#C8102E]">•</span>{" "}
+                  Frontend: Next.js, React, TypeScript, Tailwind CSS
+                </li>
+                <li>
+                  <span className="font-semibold text-[#C8102E]">•</span>{" "}
+                  Backend: Python FastAPI, SQLAlchemy, Pydantic
+                </li>
+                <li>
+                  <span className="font-semibold text-[#C8102E]">•</span>{" "}
+                  Authentication: JWT access tokens and refresh tokens
+                </li>
+                <li>
+                  <span className="font-semibold text-[#C8102E]">•</span>{" "}
+                  Database: SQLite for local development
+                </li>
+              </ul>
+            </aside>
+          </div>
+
+          <div className="mt-16 rounded-xl bg-[#971B2F] px-8 py-10 text-white shadow-sm md:flex md:items-center md:justify-between md:gap-8">
+            <div>
+              <h2 className="font-heading text-3xl font-bold">
+                Ready to help return an item?
+              </h2>
+
+              <p className="mt-3 max-w-2xl text-white/85">
+                Create a lost or found post so the SDSU community can help match
+                items with the right owner.
+              </p>
+            </div>
+
+            <Link href="/create-post">
+              <Button className="mt-8 bg-white font-heading font-bold text-[#971B2F] hover:bg-gray-100 md:mt-0">
+                Create a Post
+              </Button>
+            </Link>
+          </div>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/frontend/src/app/account/page.tsx
+++ b/frontend/src/app/account/page.tsx
@@ -3,9 +3,10 @@
 import { FormEvent, useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import Navbar from "@/components/navbar";
+import MyPostsPanel from "@/components/my-posts-panel";
 import { Button } from "@/components/ui/button";
 import { apiFetch, getApiErrorMessage } from "@/lib/api";
-import { Mail, UserRound, LogOut } from "lucide-react";
+import { LogOut } from "lucide-react";
 
 type UserResponse = {
   id: number;
@@ -162,56 +163,16 @@ export default function AccountPage() {
 
           <div className="mt-6 h-[2px] w-28 bg-[#C8102E]" />
 
-          <p className="mt-8 max-w-2xl text-xl leading-8 text-gray-700">
-            View and update your SDSU Lost &amp; Found profile information.
+          <p className="mt-8 max-w-3xl text-xl leading-8 text-gray-700">
+            Your account is used to create posts, manage item recovery, and
+            communicate with other users through the messaging system.
           </p>
         </div>
       </section>
 
       <section className="px-6 py-16 md:px-16">
-        <div className="mx-auto grid max-w-5xl items-start gap-10 md:grid-cols-[1fr_460px]">
-          <div>
-            <h2 className="font-heading text-3xl font-semibold text-gray-900">
-              Account details
-            </h2>
-
-            <p className="mt-5 text-lg leading-8 text-gray-700">
-              Your account is used to create posts, manage item recovery, and
-              communicate with other users through the messaging system.
-            </p>
-
-            <div className="mt-8 space-y-5">
-              <div className="flex items-start gap-4 rounded-xl border border-gray-200 bg-white p-5 shadow-sm">
-                <div className="flex h-11 w-11 items-center justify-center rounded-full bg-red-50 text-[#C8102E]">
-                  <UserRound size={22} />
-                </div>
-
-                <div>
-                  <h3 className="font-heading text-lg font-bold text-gray-900">
-                    Profile name
-                  </h3>
-                  <p className="mt-1 text-sm text-gray-600">
-                    This name appears in conversations with other users.
-                  </p>
-                </div>
-              </div>
-
-              <div className="flex items-start gap-4 rounded-xl border border-gray-200 bg-white p-5 shadow-sm">
-                <div className="flex h-11 w-11 items-center justify-center rounded-full bg-red-50 text-[#C8102E]">
-                  <Mail size={22} />
-                </div>
-
-                <div>
-                  <h3 className="font-heading text-lg font-bold text-gray-900">
-                    SDSU email
-                  </h3>
-                  <p className="mt-1 text-sm text-gray-600">
-                    This app is intended for SDSU campus users.
-                  </p>
-                </div>
-              </div>
-            </div>
-          </div>
+        <div className="mx-auto grid max-w-6xl items-start gap-10 lg:grid-cols-[1fr_460px]">
+          <MyPostsPanel />
 
           <div className="rounded-xl border border-gray-200 bg-white p-8 shadow-sm">
             <h2 className="font-heading text-2xl font-bold text-gray-900">

--- a/frontend/src/app/account/page.tsx
+++ b/frontend/src/app/account/page.tsx
@@ -1,0 +1,317 @@
+"use client";
+
+import { FormEvent, useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import Navbar from "@/components/navbar";
+import { Button } from "@/components/ui/button";
+import { apiFetch, getApiErrorMessage } from "@/lib/api";
+import { Mail, UserRound, LogOut } from "lucide-react";
+
+type UserResponse = {
+  id: number;
+  first_name: string;
+  last_name: string;
+  email: string;
+};
+
+type UserUpdateResponse = {
+  success: boolean;
+  user: UserResponse;
+};
+
+export default function AccountPage() {
+  const router = useRouter();
+
+  const [userId, setUserId] = useState<number | null>(null);
+  const [firstName, setFirstName] = useState("");
+  const [lastName, setLastName] = useState("");
+  const [email, setEmail] = useState("");
+
+  const [isLoading, setIsLoading] = useState(true);
+  const [isUpdating, setIsUpdating] = useState(false);
+  const [message, setMessage] = useState("");
+  const [isError, setIsError] = useState(false);
+
+  useEffect(() => {
+    async function loadAccount() {
+      const token = localStorage.getItem("token");
+      const storedUserId = localStorage.getItem("userId");
+
+      if (!token || !storedUserId) {
+        router.replace("/login?message=signin-required&redirect=/account");
+        return;
+      }
+
+      const parsedUserId = Number(storedUserId);
+
+      if (Number.isNaN(parsedUserId)) {
+        router.replace("/login?message=signin-required&redirect=/account");
+        return;
+      }
+
+      try {
+        setUserId(parsedUserId);
+
+        const userData = await apiFetch<UserResponse>(
+          `/api/v1/user/${parsedUserId}`,
+        );
+
+        setFirstName(userData.first_name);
+        setLastName(userData.last_name);
+        setEmail(userData.email);
+
+        localStorage.setItem("firstName", userData.first_name);
+        localStorage.setItem("lastName", userData.last_name);
+        localStorage.setItem("email", userData.email);
+      } catch (error) {
+        setIsError(true);
+        setMessage(getApiErrorMessage(error));
+      } finally {
+        setIsLoading(false);
+      }
+    }
+
+    loadAccount();
+  }, [router]);
+
+  async function handleUpdateAccount(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+
+    if (!userId) {
+      return;
+    }
+
+    const trimmedFirstName = firstName.trim();
+    const trimmedLastName = lastName.trim();
+    const trimmedEmail = email.trim().toLowerCase();
+
+    setMessage("");
+    setIsError(false);
+
+    if (!trimmedFirstName || !trimmedLastName || !trimmedEmail) {
+      setIsError(true);
+      setMessage("Please fill out all fields.");
+      return;
+    }
+
+    if (trimmedFirstName.length > 15 || trimmedLastName.length > 15) {
+      setIsError(true);
+      setMessage("First name and last name must be 15 characters or less.");
+      return;
+    }
+
+    if (!trimmedEmail.endsWith("@sdsu.edu")) {
+      setIsError(true);
+      setMessage("Please use a valid SDSU email address.");
+      return;
+    }
+
+    try {
+      setIsUpdating(true);
+
+      const updatedData = await apiFetch<UserUpdateResponse>(
+        `/api/v1/user/${userId}`,
+        {
+          method: "PUT",
+          body: JSON.stringify({
+            first_name: trimmedFirstName,
+            last_name: trimmedLastName,
+            email: trimmedEmail,
+          }),
+        },
+      );
+
+      setFirstName(updatedData.user.first_name);
+      setLastName(updatedData.user.last_name);
+      setEmail(updatedData.user.email);
+
+      localStorage.setItem("firstName", updatedData.user.first_name);
+      localStorage.setItem("lastName", updatedData.user.last_name);
+      localStorage.setItem("email", updatedData.user.email);
+
+      setIsError(false);
+      setMessage("Account updated successfully.");
+    } catch (error) {
+      setIsError(true);
+      setMessage(getApiErrorMessage(error));
+    } finally {
+      setIsUpdating(false);
+    }
+  }
+
+  function handleSignOut() {
+    localStorage.removeItem("token");
+    localStorage.removeItem("refresh_token");
+    localStorage.removeItem("userId");
+    localStorage.removeItem("firstName");
+    localStorage.removeItem("lastName");
+    localStorage.removeItem("email");
+
+    router.push("/");
+  }
+
+  return (
+    <main className="min-h-screen bg-white text-black">
+      <Navbar />
+
+      <section className="bg-[#f4f4f4] px-6 py-20 md:px-16">
+        <div className="mx-auto max-w-5xl">
+          <h1 className="font-heading text-5xl font-semibold tracking-tight md:text-6xl">
+            My Account
+          </h1>
+
+          <div className="mt-6 h-[2px] w-28 bg-[#C8102E]" />
+
+          <p className="mt-8 max-w-2xl text-xl leading-8 text-gray-700">
+            View and update your SDSU Lost &amp; Found profile information.
+          </p>
+        </div>
+      </section>
+
+      <section className="px-6 py-16 md:px-16">
+        <div className="mx-auto grid max-w-5xl items-start gap-10 md:grid-cols-[1fr_460px]">
+          <div>
+            <h2 className="font-heading text-3xl font-semibold text-gray-900">
+              Account details
+            </h2>
+
+            <p className="mt-5 text-lg leading-8 text-gray-700">
+              Your account is used to create posts, manage item recovery, and
+              communicate with other users through the messaging system.
+            </p>
+
+            <div className="mt-8 space-y-5">
+              <div className="flex items-start gap-4 rounded-xl border border-gray-200 bg-white p-5 shadow-sm">
+                <div className="flex h-11 w-11 items-center justify-center rounded-full bg-red-50 text-[#C8102E]">
+                  <UserRound size={22} />
+                </div>
+
+                <div>
+                  <h3 className="font-heading text-lg font-bold text-gray-900">
+                    Profile name
+                  </h3>
+                  <p className="mt-1 text-sm text-gray-600">
+                    This name appears in conversations with other users.
+                  </p>
+                </div>
+              </div>
+
+              <div className="flex items-start gap-4 rounded-xl border border-gray-200 bg-white p-5 shadow-sm">
+                <div className="flex h-11 w-11 items-center justify-center rounded-full bg-red-50 text-[#C8102E]">
+                  <Mail size={22} />
+                </div>
+
+                <div>
+                  <h3 className="font-heading text-lg font-bold text-gray-900">
+                    SDSU email
+                  </h3>
+                  <p className="mt-1 text-sm text-gray-600">
+                    This app is intended for SDSU campus users.
+                  </p>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div className="rounded-xl border border-gray-200 bg-white p-8 shadow-sm">
+            <h2 className="font-heading text-2xl font-bold text-gray-900">
+              Profile Information
+            </h2>
+
+            {isLoading ? (
+              <p className="mt-8 text-sm text-gray-600">
+                Loading account information...
+              </p>
+            ) : (
+              <form onSubmit={handleUpdateAccount} className="mt-8 space-y-5">
+                <div className="grid gap-5 sm:grid-cols-2">
+                  <div>
+                    <label
+                      htmlFor="firstName"
+                      className="block font-heading text-sm font-semibold text-gray-800"
+                    >
+                      First Name
+                    </label>
+
+                    <input
+                      id="firstName"
+                      type="text"
+                      value={firstName}
+                      onChange={(event) => setFirstName(event.target.value)}
+                      maxLength={15}
+                      className="mt-2 w-full rounded-md border border-gray-300 px-4 py-3 text-gray-900 outline-none focus:border-[#C8102E] focus:ring-2 focus:ring-[#C8102E]/20"
+                    />
+                  </div>
+
+                  <div>
+                    <label
+                      htmlFor="lastName"
+                      className="block font-heading text-sm font-semibold text-gray-800"
+                    >
+                      Last Name
+                    </label>
+
+                    <input
+                      id="lastName"
+                      type="text"
+                      value={lastName}
+                      onChange={(event) => setLastName(event.target.value)}
+                      maxLength={15}
+                      className="mt-2 w-full rounded-md border border-gray-300 px-4 py-3 text-gray-900 outline-none focus:border-[#C8102E] focus:ring-2 focus:ring-[#C8102E]/20"
+                    />
+                  </div>
+                </div>
+
+                <div>
+                  <label
+                    htmlFor="email"
+                    className="block font-heading text-sm font-semibold text-gray-800"
+                  >
+                    SDSU Email
+                  </label>
+
+                  <input
+                    id="email"
+                    type="email"
+                    value={email}
+                    onChange={(event) => setEmail(event.target.value)}
+                    className="mt-2 w-full rounded-md border border-gray-300 px-4 py-3 text-gray-900 outline-none focus:border-[#C8102E] focus:ring-2 focus:ring-[#C8102E]/20"
+                  />
+                </div>
+
+                {message && (
+                  <p
+                    className={`rounded-md px-4 py-3 text-sm ${
+                      isError
+                        ? "bg-red-50 text-red-800"
+                        : "bg-green-50 text-green-800"
+                    }`}
+                  >
+                    {message}
+                  </p>
+                )}
+
+                <Button
+                  type="submit"
+                  disabled={isUpdating}
+                  className="w-full bg-[#C8102E] py-6 font-heading text-base font-bold text-white hover:bg-[#a00d24]"
+                >
+                  {isUpdating ? "Saving Changes..." : "Save Changes"}
+                </Button>
+
+                <Button
+                  type="button"
+                  onClick={handleSignOut}
+                  className="w-full border border-gray-300 bg-white py-6 font-heading text-base font-bold text-gray-900 hover:bg-gray-100"
+                >
+                  <LogOut className="mr-2 h-4 w-4" />
+                  Sign Out
+                </Button>
+              </form>
+            )}
+          </div>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -119,6 +119,30 @@
   --sidebar-ring: oklch(0.556 0 0);
 }
 
+.modal-scrollbar {
+  scrollbar-width: thin;
+  scrollbar-color: #9ca3af transparent;
+}
+
+.modal-scrollbar::-webkit-scrollbar {
+  width: 10px;
+}
+
+.modal-scrollbar::-webkit-scrollbar-track {
+  background: transparent;
+  border-radius: 9999px;
+  margin: 12px 0;
+}
+
+.modal-scrollbar::-webkit-scrollbar-thumb {
+  background-color: #9ca3af;
+  border-radius: 9999px;
+  border: 4px solid white;
+}
+
+.modal-scrollbar::-webkit-scrollbar-thumb:hover {
+  background-color: #6b7280;
+}
 @layer base {
   * {
     @apply border-border outline-ring/50;

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -143,6 +143,30 @@
 .modal-scrollbar::-webkit-scrollbar-thumb:hover {
   background-color: #6b7280;
 }
+
+.message-panel-scrollbar {
+  scrollbar-width: thin;
+  scrollbar-color: #9ca3af transparent;
+}
+
+.message-panel-scrollbar::-webkit-scrollbar {
+  width: 9px;
+}
+
+.message-panel-scrollbar::-webkit-scrollbar-track {
+  background: transparent;
+  border-radius: 9999px;
+}
+
+.message-panel-scrollbar::-webkit-scrollbar-thumb {
+  background-color: #9ca3af;
+  border-radius: 9999px;
+  border: 3px solid white;
+}
+
+.message-panel-scrollbar::-webkit-scrollbar-thumb:hover {
+  background-color: #6b7280;
+}
 @layer base {
   * {
     @apply border-border outline-ring/50;
@@ -154,4 +178,21 @@
     @apply font-sans;
     scrollbar-gutter: stable;
   }
+}
+
+@keyframes chat-panel-in {
+  from {
+    opacity: 0;
+    transform: translateY(12px) scale(0.98);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+.animate-chat-panel-in {
+  animation: chat-panel-in 220ms ease-out;
+  transform-origin: top center;
 }

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -130,7 +130,7 @@ export default function Home() {
       {/* Main 3-column layout */}
       <div className="mx-auto grid max-w-7xl grid-cols-1 gap-6 px-4 py-4 lg:grid-cols-[220px_1fr_340px]">
         {/* Left — Filters */}
-        <aside className="h-fit rounded-lg border border-gray-200 bg-white p-5 shadow-sm">
+        <aside className="h-fit rounded-lg border border-gray-200 bg-white p-5 shadow-sm lg:sticky lg:top-6 lg:self-start">
           <h2 className="mb-4 font-heading text-sm font-bold uppercase tracking-wide text-gray-800">
             Filters
           </h2>
@@ -220,12 +220,14 @@ export default function Home() {
         </main>
 
         {/* Right — Messages */}
-        <aside>
-          <ConversationPanel
-            activeConversationId={activeConversationId}
-            refreshKey={conversationRefreshKey}
-          />
-        </aside>
+<aside className="lg:sticky lg:top-6 lg:self-start">
+  <div className="max-h-[calc(100vh-3rem)] overflow-y-auto rounded-xl">
+    <ConversationPanel
+      activeConversationId={activeConversationId}
+      refreshKey={conversationRefreshKey}
+    />
+  </div>
+</aside>
       </div>
     </div>
   );

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -69,8 +69,9 @@ export default function Home() {
         (!wantsLost && !wantsFound) ||
         (wantsLost && post.report_type === "lost") ||
         (wantsFound && post.report_type === "found");
+      const isActive = !post.given_back;
 
-      return matchesSearch && matchesStatus;
+      return isActive && matchesSearch && matchesStatus;
     });
   }, [posts, searchTerm, selectedFilters]);
 
@@ -135,7 +136,7 @@ export default function Home() {
           </h2>
 
           <ul className="space-y-3 text-sm text-gray-700">
-            {["Location", "Date", "Status: Lost", "Status: Found", "Color"].map(
+            {["Location", "Date", "Status: Lost", "Status: Found"].map(
               (filter) => (
                 <li key={filter}>
                   <label className="flex cursor-pointer items-center gap-2 hover:text-[#C8102E]">
@@ -153,7 +154,7 @@ export default function Home() {
           </ul>
 
           <p className="mt-5 text-xs leading-5 text-gray-500">
-            Status filters work now. Location, date, and color filters will be
+            Location, date, and color filters will be
             connected later.
           </p>
         </aside>

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -128,7 +128,7 @@ export default function Home() {
       </div>
 
       {/* Main 3-column layout */}
-      <div className="mx-auto grid max-w-7xl grid-cols-1 gap-6 px-4 py-4 lg:grid-cols-[220px_1fr_340px]">
+      <div className="mx-auto grid max-w-7xl grid-cols-1 gap-6 px-4 py-4 lg:grid-cols-[220px_minmax(0,1fr)_390px]">
         {/* Left — Filters */}
         <aside className="h-fit rounded-lg border border-gray-200 bg-white p-5 shadow-sm lg:sticky lg:top-6 lg:self-start">
           <h2 className="mb-4 font-heading text-sm font-bold uppercase tracking-wide text-gray-800">
@@ -220,14 +220,12 @@ export default function Home() {
         </main>
 
         {/* Right — Messages */}
-<aside className="lg:sticky lg:top-6 lg:self-start">
-  <div className="max-h-[calc(100vh-3rem)] overflow-y-auto rounded-xl">
-    <ConversationPanel
-      activeConversationId={activeConversationId}
-      refreshKey={conversationRefreshKey}
-    />
-  </div>
-</aside>
+        <aside className="lg:sticky lg:top-6 lg:self-start">
+          <ConversationPanel
+            activeConversationId={activeConversationId}
+            refreshKey={conversationRefreshKey}
+          />
+        </aside>
       </div>
     </div>
   );

--- a/frontend/src/components/conversation-panel.tsx
+++ b/frontend/src/components/conversation-panel.tsx
@@ -2,7 +2,7 @@
 
 import { FormEvent, useEffect, useState } from "react";
 import Link from "next/link";
-import { Inbox, MessageCircle, Send } from "lucide-react";
+import { Inbox, MessageCircle, Send, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
   ConversationListItem,
@@ -35,13 +35,15 @@ function getStoredUserId() {
 }
 
 export default function ConversationPanel({
-    activeConversationId = null,
-    refreshKey = 0,
+  activeConversationId = null,
+  refreshKey = 0,
 }: ConversationPanelProps) {
   const [currentUserId, setCurrentUserId] = useState<number | null>(null);
   const [isSignedIn, setIsSignedIn] = useState(false);
 
-  const [conversations, setConversations] = useState<ConversationListItem[]>([]);
+  const [conversations, setConversations] = useState<ConversationListItem[]>(
+    [],
+  );
   const [selectedConversationId, setSelectedConversationId] = useState<
     number | null
   >(null);
@@ -65,6 +67,9 @@ export default function ConversationPanel({
     setIsSignedIn(Boolean(token));
 
     if (!token) {
+      setConversations([]);
+      setSelectedConversationId(null);
+      setMessages([]);
       setIsLoadingConversations(false);
       return;
     }
@@ -81,16 +86,18 @@ export default function ConversationPanel({
         activeConversationId &&
         data.some((conversation) => conversation.id === activeConversationId);
 
-    if (shouldOpenActiveConversation) {
+      if (shouldOpenActiveConversation) {
         setSelectedConversationId(activeConversationId);
-    } else if (!selectedConversationId && data.length > 0) {
-        setSelectedConversationId(data[0].id);
-    } else if (
+        return;
+      }
+
+      if (
         selectedConversationId &&
         !data.some((conversation) => conversation.id === selectedConversationId)
-    ) {
-        setSelectedConversationId(data[0]?.id ?? null);
-    }
+      ) {
+        setSelectedConversationId(null);
+        setMessages([]);
+      }
     } catch (error) {
       setErrorMessage(getApiErrorMessage(error));
     } finally {
@@ -111,6 +118,13 @@ export default function ConversationPanel({
     } finally {
       setIsLoadingMessages(false);
     }
+  }
+
+  function handleCloseConversation() {
+    setSelectedConversationId(null);
+    setMessages([]);
+    setNewMessage("");
+    setErrorMessage("");
   }
 
   async function handleSendMessage(event: FormEvent<HTMLFormElement>) {
@@ -144,29 +158,30 @@ export default function ConversationPanel({
   }
 
   useEffect(() => {
-  const timeoutId = window.setTimeout(() => {
-    loadConversations();
-  }, 0);
+    const timeoutId = window.setTimeout(() => {
+      loadConversations();
+    }, 0);
 
-  return () => window.clearTimeout(timeoutId);
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-}, [refreshKey]);
+    return () => window.clearTimeout(timeoutId);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [refreshKey]);
 
-useEffect(() => {
-  const timeoutId = window.setTimeout(() => {
-    if (selectedConversationId) {
-      loadMessages(selectedConversationId);
-    } else {
-      setMessages([]);
-    }
-  }, 0);
+  useEffect(() => {
+    const timeoutId = window.setTimeout(() => {
+      if (selectedConversationId) {
+        loadMessages(selectedConversationId);
+      } else {
+        setMessages([]);
+      }
+    }, 0);
 
-  return () => window.clearTimeout(timeoutId);
-}, [selectedConversationId]);
+    return () => window.clearTimeout(timeoutId);
+  }, [selectedConversationId]);
 
   return (
-    <section className="min-h-[470px] rounded-xl border border-gray-200 bg-white p-5 shadow-sm">
-      <div className="flex items-center gap-3 border-b border-gray-100 pb-4">
+    <section className="overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm">
+      <div className="message-panel-scrollbar mr-3 flex max-h-[calc(100vh-3rem)] min-h-[520px] flex-col overflow-y-auto p-5 pr-4">
+        <div className="flex items-center gap-3 border-b border-gray-100 pb-4">
         <div className="flex h-10 w-10 items-center justify-center rounded-full bg-red-50 text-[#C8102E]">
           <Inbox size={22} />
         </div>
@@ -182,7 +197,7 @@ useEffect(() => {
       </div>
 
       {!isSignedIn && !isLoadingConversations && (
-        <div className="flex min-h-[330px] items-center justify-center text-center">
+        <div className="flex min-h-[420px] flex-1 items-center justify-center text-center">
           <div>
             <h3 className="font-heading text-xl font-bold text-gray-900">
               Sign in to view messages
@@ -205,7 +220,7 @@ useEffect(() => {
       {isSignedIn && (
         <>
           {isLoadingConversations && (
-            <div className="flex min-h-[330px] items-center justify-center text-center">
+            <div className="flex flex-1 items-center justify-center text-center">
               <p className="text-sm text-gray-600">Loading conversations...</p>
             </div>
           )}
@@ -217,7 +232,7 @@ useEffect(() => {
           )}
 
           {!isLoadingConversations && conversations.length === 0 && (
-            <div className="flex min-h-[330px] items-center justify-center text-center">
+            <div className="flex min-h-[360px] flex-1 items-center justify-center text-center">
               <div>
                 <MessageCircle className="mx-auto h-10 w-10 text-[#C8102E]" />
 
@@ -234,109 +249,153 @@ useEffect(() => {
           )}
 
           {!isLoadingConversations && conversations.length > 0 && (
-            <div className="mt-5 space-y-5">
-              <div className="max-h-44 space-y-2 overflow-y-auto pr-1">
-                {conversations.map((conversation) => {
-                  const isSelected = conversation.id === selectedConversationId;
+  <div className="mt-5 space-y-5">
+    {/* Top — Active chat */}
+    {!selectedConversationId && (
+      <div className="animate-chat-panel-in rounded-lg border border-dashed border-gray-300 bg-gray-50 px-4 py-10 text-center">
+        <MessageCircle className="mx-auto h-10 w-10 text-[#C8102E]" />
 
-                  return (
-                    <button
-                      key={conversation.id}
-                      type="button"
-                      onClick={() => setSelectedConversationId(conversation.id)}
-                      className={`w-full rounded-lg border px-4 py-3 text-left transition ${
-                        isSelected
-                          ? "border-[#C8102E] bg-red-50"
-                          : "border-gray-200 bg-white hover:border-gray-300"
-                      }`}
-                    >
-                      <p className="font-heading text-sm font-bold text-gray-900">
-                        {conversation.partner_name}
-                      </p>
+        <h3 className="mt-4 font-heading text-lg font-bold text-gray-900">
+          Select a conversation
+        </h3>
 
-                      <p className="mt-1 line-clamp-1 text-xs text-gray-500">
-                        {conversation.last_message || "No messages yet"}
-                      </p>
-                    </button>
-                  );
-                })}
-              </div>
+        <p className="mt-2 text-sm leading-6 text-gray-600">
+          Click a conversation below to open the chat.
+        </p>
+      </div>
+    )}
 
-              <div className="rounded-lg border border-gray-200">
-                <div className="border-b border-gray-100 px-4 py-3">
-                  <h3 className="font-heading text-sm font-bold text-gray-900">
-                    {selectedConversation
-                      ? selectedConversation.partner_name
-                      : "Select a conversation"}
-                  </h3>
-                </div>
+    {selectedConversationId && selectedConversation && (
+      <div className="animate-chat-panel-in rounded-lg border border-gray-200 bg-white shadow-sm">
+        <div className="flex items-center justify-between border-b border-gray-100 px-4 py-3">
+          <div>
+            <h3 className="font-heading text-sm font-bold text-gray-900">
+              {selectedConversation.partner_name}
+            </h3>
 
-                <div className="max-h-64 min-h-52 space-y-3 overflow-y-auto px-4 py-4">
-                  {isLoadingMessages && (
-                    <p className="text-center text-sm text-gray-500">
-                      Loading messages...
-                    </p>
-                  )}
+            <p className="mt-1 text-xs text-gray-500">
+              Active conversation
+            </p>
+          </div>
 
-                  {!isLoadingMessages && messages.length === 0 && (
-                    <p className="text-center text-sm text-gray-500">
-                      No messages in this conversation yet.
-                    </p>
-                  )}
+          <button
+            type="button"
+            onClick={handleCloseConversation}
+            className="rounded-full p-2 text-gray-500 transition hover:bg-gray-100 hover:text-gray-900"
+            aria-label="Close conversation"
+          >
+            <X size={20} />
+          </button>
+        </div>
 
-                  {!isLoadingMessages &&
-                    messages.map((message) => {
-                      const isMine = message.sender_id === currentUserId;
-
-                      return (
-                        <div
-                          key={message.id}
-                          className={`flex ${
-                            isMine ? "justify-end" : "justify-start"
-                          }`}
-                        >
-                          <div
-                            className={`max-w-[85%] rounded-lg px-3 py-2 text-sm leading-5 ${
-                              isMine
-                                ? "bg-[#C8102E] text-white"
-                                : "bg-gray-100 text-gray-800"
-                            }`}
-                          >
-                            {message.message_text}
-                          </div>
-                        </div>
-                      );
-                    })}
-                </div>
-
-                <form
-                  onSubmit={handleSendMessage}
-                  className="border-t border-gray-100 p-3"
-                >
-                  <textarea
-                    value={newMessage}
-                    onChange={(event) => setNewMessage(event.target.value)}
-                    placeholder="Write a message..."
-                    rows={3}
-                    className="w-full resize-none rounded-md border border-gray-300 px-3 py-2 text-sm text-gray-900 outline-none focus:border-[#C8102E] focus:ring-2 focus:ring-[#C8102E]/20"
-                  />
-
-                  <Button
-                    type="submit"
-                    disabled={
-                      isSending || !selectedConversationId || !newMessage.trim()
-                    }
-                    className="mt-3 w-full bg-[#C8102E] font-heading font-bold text-white hover:bg-[#a00d24] disabled:cursor-not-allowed disabled:opacity-50"
-                  >
-                    <Send className="mr-2 h-4 w-4" />
-                    {isSending ? "Sending..." : "Send"}
-                  </Button>
-                </form>
-              </div>
-            </div>
+        <div className="message-panel-scrollbar mr-2 max-h-56 min-h-36 space-y-3 overflow-y-auto px-4 py-4 pr-5">
+          {isLoadingMessages && (
+            <p className="text-center text-sm text-gray-500">
+              Loading messages...
+            </p>
           )}
+
+          {!isLoadingMessages && messages.length === 0 && (
+            <p className="text-center text-sm text-gray-500">
+              No messages in this conversation yet.
+            </p>
+          )}
+
+          {!isLoadingMessages &&
+            messages.map((message) => {
+              const isMine = message.sender_id === currentUserId;
+
+              return (
+                <div
+                  key={message.id}
+                  className={`flex ${
+                    isMine ? "justify-end" : "justify-start"
+                  }`}
+                >
+                  <div
+                    className={`max-w-[85%] rounded-lg px-3 py-2 text-sm leading-5 ${
+                      isMine
+                        ? "bg-[#C8102E] text-white"
+                        : "bg-gray-100 text-gray-800"
+                    }`}
+                  >
+                    {message.message_text}
+                  </div>
+                </div>
+              );
+            })}
+        </div>
+
+        <form
+          onSubmit={handleSendMessage}
+          className="border-t border-gray-100 p-3"
+        >
+          <textarea
+            value={newMessage}
+            onChange={(event) => setNewMessage(event.target.value)}
+            placeholder="Write a message..."
+            rows={3}
+            className="w-full resize-none rounded-md border border-gray-300 px-3 py-2 text-sm text-gray-900 outline-none transition focus:border-[#C8102E] focus:ring-2 focus:ring-[#C8102E]/20"
+          />
+
+          <Button
+            type="submit"
+            disabled={
+              isSending || !selectedConversationId || !newMessage.trim()
+            }
+            className="mt-3 w-full bg-[#C8102E] font-heading font-bold text-white hover:bg-[#a00d24] disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            <Send className="mr-2 h-4 w-4" />
+            {isSending ? "Sending..." : "Send"}
+          </Button>
+        </form>
+      </div>
+    )}
+
+    {/* Bottom — Conversation list */}
+    <div className="border-t border-gray-100 pt-4">
+      <div className="mb-3 flex items-center justify-between">
+        <h3 className="font-heading text-sm font-bold uppercase tracking-wide text-gray-800">
+          Conversations
+        </h3>
+
+        <p className="text-xs text-gray-500">
+          {conversations.length} total
+        </p>
+      </div>
+
+      <div className="message-panel-scrollbar mr-2 max-h-52 space-y-2 overflow-y-auto py-1 pl-1 pr-5">
+        {conversations.map((conversation) => {
+          const isSelected = conversation.id === selectedConversationId;
+
+          return (
+            <button
+              key={conversation.id}
+              type="button"
+              onClick={() => setSelectedConversationId(conversation.id)}
+              className={`w-full rounded-lg border px-3 py-2.5 text-left transition-all duration-200 ${
+                isSelected
+                  ? "border-[#C8102E] bg-red-50 shadow-sm"
+                  : "border-gray-200 bg-white hover:border-gray-300 hover:bg-gray-50 hover:shadow-sm"
+              }`}
+            >
+              <p className="font-heading text-sm font-bold text-gray-900">
+                {conversation.partner_name}
+              </p>
+
+              <p className="mt-1 line-clamp-1 text-xs text-gray-500">
+                {conversation.last_message || "No messages yet"}
+              </p>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  </div>
+)}
         </>
       )}
+      </div>
     </section>
   );
 }

--- a/frontend/src/components/my-posts-panel.tsx
+++ b/frontend/src/components/my-posts-panel.tsx
@@ -1,0 +1,275 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { apiFetch, getApiErrorMessage } from "@/lib/api";
+import {
+  CheckCircle2,
+  MapPin,
+  PackageOpen,
+  RotateCcw,
+  Trash2,
+} from "lucide-react";
+
+type ItemPost = {
+  id: number;
+  user_id: number;
+  title: string;
+  description: string;
+  location: string;
+  report_type: "lost" | "found";
+  image_url: string | null;
+  given_back: boolean;
+  created_at: string;
+};
+
+type SuccessResponse = {
+  success: boolean;
+};
+
+function formatDate(date: string) {
+  return new Intl.DateTimeFormat("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  }).format(new Date(date));
+}
+
+export default function MyPostsPanel() {
+  const [posts, setPosts] = useState<ItemPost[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [actionPostId, setActionPostId] = useState<number | null>(null);
+  const [message, setMessage] = useState("");
+  const [isError, setIsError] = useState(false);
+
+  async function loadMyPosts() {
+    try {
+      setMessage("");
+      setIsError(false);
+      setIsLoading(true);
+
+      const data = await apiFetch<ItemPost[]>("/api/v1/home/my-posts");
+
+      setPosts(data);
+    } catch (error) {
+      setIsError(true);
+      setMessage(getApiErrorMessage(error));
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  async function handleToggleReturned(post: ItemPost) {
+    try {
+      setActionPostId(post.id);
+      setMessage("");
+      setIsError(false);
+
+      await apiFetch<SuccessResponse>(`/api/v1/home/${post.id}`, {
+        method: "PUT",
+        body: JSON.stringify({
+          given_back: !post.given_back,
+        }),
+      });
+
+      setPosts((currentPosts) =>
+        currentPosts.map((currentPost) =>
+          currentPost.id === post.id
+            ? { ...currentPost, given_back: !currentPost.given_back }
+            : currentPost,
+        ),
+      );
+
+      setMessage(
+        post.given_back
+          ? "Post marked as active again. It will show on the home feed."
+          : "Post marked as returned. It will no longer show on the home feed.",
+      );
+    } catch (error) {
+      setIsError(true);
+      setMessage(getApiErrorMessage(error));
+    } finally {
+      setActionPostId(null);
+    }
+  }
+
+  async function handleDeletePost(postId: number) {
+    const shouldDelete = window.confirm(
+      "Are you sure you want to delete this post?",
+    );
+
+    if (!shouldDelete) {
+      return;
+    }
+
+    try {
+      setActionPostId(postId);
+      setMessage("");
+      setIsError(false);
+
+      await apiFetch<SuccessResponse>(`/api/v1/home/${postId}`, {
+        method: "DELETE",
+      });
+
+      setPosts((currentPosts) =>
+        currentPosts.filter((currentPost) => currentPost.id !== postId),
+      );
+
+      setMessage("Post deleted successfully.");
+    } catch (error) {
+      setIsError(true);
+      setMessage(getApiErrorMessage(error));
+    } finally {
+      setActionPostId(null);
+    }
+  }
+
+  useEffect(() => {
+    loadMyPosts();
+  }, []);
+
+  return (
+    <section className="rounded-xl border border-gray-200 bg-white p-8 shadow-sm">
+      <div className="flex flex-col gap-4 border-b border-gray-100 pb-6 md:flex-row md:items-center md:justify-between">
+        <div>
+          <h2 className="font-heading text-2xl font-bold text-gray-900">
+            My Posts
+          </h2>
+
+          <p className="mt-2 text-sm text-gray-600">
+            Manage the lost and found posts created by your account.
+          </p>
+        </div>
+
+        <Button
+          type="button"
+          onClick={loadMyPosts}
+          className="bg-[#C8102E] font-heading font-bold text-white hover:bg-[#a00d24]"
+        >
+          Refresh
+        </Button>
+      </div>
+
+      {message && (
+        <p
+          className={`mt-5 rounded-md px-4 py-3 text-sm ${
+            isError ? "bg-red-50 text-red-800" : "bg-green-50 text-green-800"
+          }`}
+        >
+          {message}
+        </p>
+      )}
+
+      {isLoading && (
+        <div className="flex min-h-44 items-center justify-center text-center">
+          <p className="text-sm text-gray-600">Loading your posts...</p>
+        </div>
+      )}
+
+      {!isLoading && posts.length === 0 && (
+        <div className="flex min-h-52 items-center justify-center text-center">
+          <div>
+            <PackageOpen className="mx-auto h-12 w-12 text-[#C8102E]" />
+
+            <h3 className="mt-4 font-heading text-xl font-bold text-gray-900">
+              No posts yet
+            </h3>
+
+            <p className="mt-3 max-w-md text-sm leading-6 text-gray-600">
+              Once you create a lost or found item post, it will appear here so
+              you can manage it.
+            </p>
+          </div>
+        </div>
+      )}
+
+      {!isLoading && posts.length > 0 && (
+        <div className="mt-6 grid gap-5">
+          {posts.map((post) => {
+            const isLost = post.report_type === "lost";
+            const isBusy = actionPostId === post.id;
+
+            return (
+              <article
+                key={post.id}
+                className="rounded-xl border border-gray-200 bg-gray-50 p-5"
+              >
+                <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+                  <div>
+                    <div className="flex flex-wrap items-center gap-2">
+                      <h3 className="font-heading text-xl font-bold text-gray-900">
+                        {post.title}
+                      </h3>
+
+                      <Badge className="bg-[#C8102E] text-white">
+                        {isLost ? "Lost" : "Found"}
+                      </Badge>
+
+                      {post.given_back ? (
+                        <Badge className="bg-gray-800 text-white">
+                          Returned
+                        </Badge>
+                      ) : (
+                        <Badge className="bg-blue-600 text-white">Active</Badge>
+                      )}
+                    </div>
+
+                    <p className="mt-2 flex items-center gap-1 text-xs text-gray-500">
+                      <MapPin size={14} />
+                      {post.location} · {formatDate(post.created_at)}
+                    </p>
+
+                    <p className="mt-4 text-sm leading-6 text-gray-700">
+                      {post.description}
+                    </p>
+                  </div>
+
+                  {post.image_url && (
+                    // eslint-disable-next-line @next/next/no-img-element
+                    <img
+                      src={post.image_url}
+                      alt={post.title}
+                      className="h-28 w-full rounded-lg object-cover md:w-36"
+                    />
+                  )}
+                </div>
+
+                <div className="mt-5 flex flex-col gap-3 sm:flex-row">
+                  <Button
+                    type="button"
+                    disabled={isBusy}
+                    onClick={() => handleToggleReturned(post)}
+                    className="bg-[#C8102E] font-heading font-bold text-white hover:bg-[#a00d24] disabled:cursor-not-allowed disabled:opacity-60"
+                  >
+                    {post.given_back ? (
+                      <>
+                        <RotateCcw className="mr-2 h-4 w-4" />
+                        Mark Active
+                      </>
+                    ) : (
+                      <>
+                        <CheckCircle2 className="mr-2 h-4 w-4" />
+                        Mark Returned
+                      </>
+                    )}
+                  </Button>
+
+                  <Button
+                    type="button"
+                    disabled={isBusy}
+                    onClick={() => handleDeletePost(post.id)}
+                    className="border border-red-200 bg-white font-heading font-bold text-red-700 hover:bg-red-50 disabled:cursor-not-allowed disabled:opacity-60"
+                  >
+                    <Trash2 className="mr-2 h-4 w-4" />
+                    Delete Post
+                  </Button>
+                </div>
+              </article>
+            );
+          })}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/frontend/src/components/my-posts-panel.tsx
+++ b/frontend/src/components/my-posts-panel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { FormEvent, useEffect, useState } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { apiFetch, getApiErrorMessage } from "@/lib/api";
@@ -8,8 +8,10 @@ import {
   CheckCircle2,
   MapPin,
   PackageOpen,
+  Pencil,
   RotateCcw,
   Trash2,
+  X,
 } from "lucide-react";
 
 type ItemPost = {
@@ -43,6 +45,16 @@ export default function MyPostsPanel() {
   const [message, setMessage] = useState("");
   const [isError, setIsError] = useState(false);
 
+  const [editingPost, setEditingPost] = useState<ItemPost | null>(null);
+  const [editTitle, setEditTitle] = useState("");
+  const [editDescription, setEditDescription] = useState("");
+  const [editLocation, setEditLocation] = useState("");
+  const [editReportType, setEditReportType] = useState<"lost" | "found">(
+    "lost",
+  );
+  const [editImageUrl, setEditImageUrl] = useState("");
+  const [isSavingEdit, setIsSavingEdit] = useState(false);
+
   async function loadMyPosts() {
     try {
       setMessage("");
@@ -57,6 +69,87 @@ export default function MyPostsPanel() {
       setMessage(getApiErrorMessage(error));
     } finally {
       setIsLoading(false);
+    }
+  }
+
+  function openEditModal(post: ItemPost) {
+    setEditingPost(post);
+    setEditTitle(post.title);
+    setEditDescription(post.description);
+    setEditLocation(post.location);
+    setEditReportType(post.report_type);
+    setEditImageUrl(post.image_url || "");
+    setMessage("");
+    setIsError(false);
+  }
+
+  function closeEditModal() {
+    setEditingPost(null);
+    setEditTitle("");
+    setEditDescription("");
+    setEditLocation("");
+    setEditReportType("lost");
+    setEditImageUrl("");
+    setIsSavingEdit(false);
+  }
+
+  async function handleSaveEdit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+
+    if (!editingPost) {
+      return;
+    }
+
+    const trimmedTitle = editTitle.trim();
+    const trimmedDescription = editDescription.trim();
+    const trimmedLocation = editLocation.trim();
+    const trimmedImageUrl = editImageUrl.trim();
+
+    if (!trimmedTitle || !trimmedDescription || !trimmedLocation) {
+      setIsError(true);
+      setMessage("Please fill out title, description, and location.");
+      return;
+    }
+
+    try {
+      setIsSavingEdit(true);
+      setMessage("");
+      setIsError(false);
+
+      await apiFetch<SuccessResponse>(`/api/v1/home/${editingPost.id}`, {
+        method: "PUT",
+        body: JSON.stringify({
+          title: trimmedTitle,
+          description: trimmedDescription,
+          location: trimmedLocation,
+          report_type: editReportType,
+          image_url: trimmedImageUrl || null,
+        }),
+      });
+
+      setPosts((currentPosts) =>
+        currentPosts.map((currentPost) =>
+          currentPost.id === editingPost.id
+            ? {
+                ...currentPost,
+                title: trimmedTitle,
+                description: trimmedDescription,
+                location: trimmedLocation,
+                report_type: editReportType,
+                image_url: trimmedImageUrl || null,
+              }
+            : currentPost,
+        ),
+      );
+
+      closeEditModal();
+      setIsError(false);
+      setMessage("Post updated successfully.");
+    } catch (error) {
+      setIsError(true);
+      setMessage(getApiErrorMessage(error));
+    } finally {
+      setIsSavingEdit(false);
     }
   }
 
@@ -130,146 +223,301 @@ export default function MyPostsPanel() {
   }, []);
 
   return (
-    <section className="rounded-xl border border-gray-200 bg-white p-8 shadow-sm">
-      <div className="flex flex-col gap-4 border-b border-gray-100 pb-6 md:flex-row md:items-center md:justify-between">
-        <div>
-          <h2 className="font-heading text-2xl font-bold text-gray-900">
-            My Posts
-          </h2>
-
-          <p className="mt-2 text-sm text-gray-600">
-            Manage the lost and found posts created by your account.
-          </p>
-        </div>
-
-        <Button
-          type="button"
-          onClick={loadMyPosts}
-          className="bg-[#C8102E] font-heading font-bold text-white hover:bg-[#a00d24]"
-        >
-          Refresh
-        </Button>
-      </div>
-
-      {message && (
-        <p
-          className={`mt-5 rounded-md px-4 py-3 text-sm ${
-            isError ? "bg-red-50 text-red-800" : "bg-green-50 text-green-800"
-          }`}
-        >
-          {message}
-        </p>
-      )}
-
-      {isLoading && (
-        <div className="flex min-h-44 items-center justify-center text-center">
-          <p className="text-sm text-gray-600">Loading your posts...</p>
-        </div>
-      )}
-
-      {!isLoading && posts.length === 0 && (
-        <div className="flex min-h-52 items-center justify-center text-center">
+    <>
+      <section className="rounded-xl border border-gray-200 bg-white p-8 shadow-sm">
+        <div className="flex flex-col gap-4 border-b border-gray-100 pb-6 md:flex-row md:items-center md:justify-between">
           <div>
-            <PackageOpen className="mx-auto h-12 w-12 text-[#C8102E]" />
+            <h2 className="font-heading text-2xl font-bold text-gray-900">
+              My Posts
+            </h2>
 
-            <h3 className="mt-4 font-heading text-xl font-bold text-gray-900">
-              No posts yet
-            </h3>
-
-            <p className="mt-3 max-w-md text-sm leading-6 text-gray-600">
-              Once you create a lost or found item post, it will appear here so
-              you can manage it.
+            <p className="mt-2 text-sm text-gray-600">
+              Manage the lost and found posts created by your account.
             </p>
+          </div>
+
+          <Button
+            type="button"
+            onClick={loadMyPosts}
+            className="bg-[#C8102E] font-heading font-bold text-white hover:bg-[#a00d24]"
+          >
+            Refresh
+          </Button>
+        </div>
+
+        {message && (
+          <p
+            className={`mt-5 rounded-md px-4 py-3 text-sm ${
+              isError ? "bg-red-50 text-red-800" : "bg-green-50 text-green-800"
+            }`}
+          >
+            {message}
+          </p>
+        )}
+
+        {isLoading && (
+          <div className="flex min-h-44 items-center justify-center text-center">
+            <p className="text-sm text-gray-600">Loading your posts...</p>
+          </div>
+        )}
+
+        {!isLoading && posts.length === 0 && (
+          <div className="flex min-h-52 items-center justify-center text-center">
+            <div>
+              <PackageOpen className="mx-auto h-12 w-12 text-[#C8102E]" />
+
+              <h3 className="mt-4 font-heading text-xl font-bold text-gray-900">
+                No posts yet
+              </h3>
+
+              <p className="mt-3 max-w-md text-sm leading-6 text-gray-600">
+                Once you create a lost or found item post, it will appear here so
+                you can manage it.
+              </p>
+            </div>
+          </div>
+        )}
+
+        {!isLoading && posts.length > 0 && (
+          <div className="mt-6 grid gap-5">
+            {posts.map((post) => {
+              const isLost = post.report_type === "lost";
+              const isBusy = actionPostId === post.id;
+
+              return (
+                <article
+                  key={post.id}
+                  className="rounded-xl border border-gray-200 bg-gray-50 p-5"
+                >
+                  <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+                    <div>
+                      <div className="flex flex-wrap items-center gap-2">
+                        <h3 className="font-heading text-xl font-bold text-gray-900">
+                          {post.title}
+                        </h3>
+
+                        <Badge className="bg-[#C8102E] text-white">
+                          {isLost ? "Lost" : "Found"}
+                        </Badge>
+
+                        {post.given_back ? (
+                          <Badge className="bg-gray-800 text-white">
+                            Returned
+                          </Badge>
+                        ) : (
+                          <Badge className="bg-blue-600 text-white">
+                            Active
+                          </Badge>
+                        )}
+                      </div>
+
+                      <p className="mt-2 flex items-center gap-1 text-xs text-gray-500">
+                        <MapPin size={14} />
+                        {post.location} · {formatDate(post.created_at)}
+                      </p>
+
+                      <p className="mt-4 text-sm leading-6 text-gray-700">
+                        {post.description}
+                      </p>
+                    </div>
+
+                    {post.image_url && (
+                      // eslint-disable-next-line @next/next/no-img-element
+                      <img
+                        src={post.image_url}
+                        alt={post.title}
+                        className="h-28 w-full rounded-lg object-cover md:w-36"
+                      />
+                    )}
+                  </div>
+
+                  <div className="mt-5 grid gap-3 sm:grid-cols-3">
+                    <Button
+                      type="button"
+                      disabled={isBusy}
+                      onClick={() => handleToggleReturned(post)}
+                      className="bg-[#C8102E] font-heading font-bold text-white hover:bg-[#a00d24] disabled:cursor-not-allowed disabled:opacity-60"
+                    >
+                      {post.given_back ? (
+                        <>
+                          <RotateCcw className="mr-2 h-4 w-4" />
+                          Mark Active
+                        </>
+                      ) : (
+                        <>
+                          <CheckCircle2 className="mr-2 h-4 w-4" />
+                          Mark Returned
+                        </>
+                      )}
+                    </Button>
+
+                    <Button
+                      type="button"
+                      disabled={isBusy}
+                      onClick={() => openEditModal(post)}
+                      className="border border-gray-300 bg-white font-heading font-bold text-gray-900 hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-60"
+                    >
+                      <Pencil className="mr-2 h-4 w-4" />
+                      Edit Post
+                    </Button>
+
+                    <Button
+                      type="button"
+                      disabled={isBusy}
+                      onClick={() => handleDeletePost(post.id)}
+                      className="border border-red-200 bg-white font-heading font-bold text-red-700 hover:bg-red-50 disabled:cursor-not-allowed disabled:opacity-60"
+                    >
+                      <Trash2 className="mr-2 h-4 w-4" />
+                      Delete Post
+                    </Button>
+                  </div>
+                </article>
+              );
+            })}
+          </div>
+        )}
+      </section>
+
+      {editingPost && (
+        <div className="fixed inset-0 z-50 flex items-start justify-center overflow-y-auto bg-black/60 px-4 py-6 md:items-center">
+          <div className="w-full max-w-xl overflow-hidden rounded-xl bg-white shadow-xl">
+            <div className="modal-scrollbar mr-2 max-h-[90vh] overflow-y-auto p-5 pr-7">
+              <div className="flex items-start justify-between border-b border-gray-100 pb-4">
+              <div>
+                <h2 className="font-heading text-2xl font-bold text-gray-900">
+                  Edit Post
+                </h2>
+
+                <p className="mt-1 text-sm text-gray-600">
+                  Update the item information below.
+                </p>
+              </div>
+
+              <button
+                type="button"
+                onClick={closeEditModal}
+                className="rounded-full p-2 text-gray-500 hover:bg-gray-100 hover:text-gray-900"
+                aria-label="Close edit post modal"
+              >
+                <X size={22} />
+              </button>
+            </div>
+
+            <form onSubmit={handleSaveEdit} className="mt-5 space-y-4">
+              <div>
+                <label
+                  htmlFor="editReportType"
+                  className="block font-heading text-sm font-semibold text-gray-800"
+                >
+                  Report Type
+                </label>
+
+                <select
+                  id="editReportType"
+                  value={editReportType}
+                  onChange={(event) =>
+                    setEditReportType(event.target.value as "lost" | "found")
+                  }
+                  className="mt-2 w-full rounded-md border border-gray-300 bg-white px-4 py-3 text-gray-900 outline-none focus:border-[#C8102E] focus:ring-2 focus:ring-[#C8102E]/20"
+                >
+                  <option value="lost">Lost Item</option>
+                  <option value="found">Found Item</option>
+                </select>
+              </div>
+
+              <div>
+                <label
+                  htmlFor="editTitle"
+                  className="block font-heading text-sm font-semibold text-gray-800"
+                >
+                  Item Title
+                </label>
+
+                <input
+                  id="editTitle"
+                  type="text"
+                  value={editTitle}
+                  onChange={(event) => setEditTitle(event.target.value)}
+                  maxLength={255}
+                  className="mt-2 w-full rounded-md border border-gray-300 px-4 py-3 text-gray-900 outline-none focus:border-[#C8102E] focus:ring-2 focus:ring-[#C8102E]/20"
+                />
+              </div>
+
+              <div>
+                <label
+                  htmlFor="editDescription"
+                  className="block font-heading text-sm font-semibold text-gray-800"
+                >
+                  Description
+                </label>
+
+                <textarea
+                  id="editDescription"
+                  value={editDescription}
+                  onChange={(event) => setEditDescription(event.target.value)}
+                  rows={3}
+                  className="mt-2 w-full resize-none rounded-md border border-gray-300 px-4 py-3 text-gray-900 outline-none focus:border-[#C8102E] focus:ring-2 focus:ring-[#C8102E]/20"
+                />
+              </div>
+
+              <div>
+                <label
+                  htmlFor="editLocation"
+                  className="block font-heading text-sm font-semibold text-gray-800"
+                >
+                  Location
+                </label>
+
+                <input
+                  id="editLocation"
+                  type="text"
+                  value={editLocation}
+                  onChange={(event) => setEditLocation(event.target.value)}
+                  maxLength={255}
+                  className="mt-2 w-full rounded-md border border-gray-300 px-4 py-3 text-gray-900 outline-none focus:border-[#C8102E] focus:ring-2 focus:ring-[#C8102E]/20"
+                />
+              </div>
+
+              <div>
+                <label
+                  htmlFor="editImageUrl"
+                  className="block font-heading text-sm font-semibold text-gray-800"
+                >
+                  Image URL Optional
+                </label>
+
+                <input
+                  id="editImageUrl"
+                  type="url"
+                  value={editImageUrl}
+                  onChange={(event) => setEditImageUrl(event.target.value)}
+                  placeholder="Leave empty to remove the image URL"
+                  className="mt-2 w-full rounded-md border border-gray-300 px-4 py-3 text-gray-900 outline-none focus:border-[#C8102E] focus:ring-2 focus:ring-[#C8102E]/20"
+                />
+              </div>
+
+              <div className="flex flex-col-reverse gap-3 pt-2 sm:flex-row sm:justify-end">
+                <Button
+                  type="button"
+                  onClick={closeEditModal}
+                  className="border border-gray-300 bg-white font-heading font-bold text-gray-900 hover:bg-gray-100"
+                >
+                  Cancel
+                </Button>
+
+                <Button
+                  type="submit"
+                  disabled={isSavingEdit}
+                  className="bg-[#C8102E] font-heading font-bold text-white hover:bg-[#a00d24] disabled:cursor-not-allowed disabled:opacity-60"
+                >
+                  {isSavingEdit ? "Saving..." : "Save Changes"}
+                </Button>
+              </div>
+            </form>
+          </div>
           </div>
         </div>
       )}
-
-      {!isLoading && posts.length > 0 && (
-        <div className="mt-6 grid gap-5">
-          {posts.map((post) => {
-            const isLost = post.report_type === "lost";
-            const isBusy = actionPostId === post.id;
-
-            return (
-              <article
-                key={post.id}
-                className="rounded-xl border border-gray-200 bg-gray-50 p-5"
-              >
-                <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
-                  <div>
-                    <div className="flex flex-wrap items-center gap-2">
-                      <h3 className="font-heading text-xl font-bold text-gray-900">
-                        {post.title}
-                      </h3>
-
-                      <Badge className="bg-[#C8102E] text-white">
-                        {isLost ? "Lost" : "Found"}
-                      </Badge>
-
-                      {post.given_back ? (
-                        <Badge className="bg-gray-800 text-white">
-                          Returned
-                        </Badge>
-                      ) : (
-                        <Badge className="bg-blue-600 text-white">Active</Badge>
-                      )}
-                    </div>
-
-                    <p className="mt-2 flex items-center gap-1 text-xs text-gray-500">
-                      <MapPin size={14} />
-                      {post.location} · {formatDate(post.created_at)}
-                    </p>
-
-                    <p className="mt-4 text-sm leading-6 text-gray-700">
-                      {post.description}
-                    </p>
-                  </div>
-
-                  {post.image_url && (
-                    // eslint-disable-next-line @next/next/no-img-element
-                    <img
-                      src={post.image_url}
-                      alt={post.title}
-                      className="h-28 w-full rounded-lg object-cover md:w-36"
-                    />
-                  )}
-                </div>
-
-                <div className="mt-5 flex flex-col gap-3 sm:flex-row">
-                  <Button
-                    type="button"
-                    disabled={isBusy}
-                    onClick={() => handleToggleReturned(post)}
-                    className="bg-[#C8102E] font-heading font-bold text-white hover:bg-[#a00d24] disabled:cursor-not-allowed disabled:opacity-60"
-                  >
-                    {post.given_back ? (
-                      <>
-                        <RotateCcw className="mr-2 h-4 w-4" />
-                        Mark Active
-                      </>
-                    ) : (
-                      <>
-                        <CheckCircle2 className="mr-2 h-4 w-4" />
-                        Mark Returned
-                      </>
-                    )}
-                  </Button>
-
-                  <Button
-                    type="button"
-                    disabled={isBusy}
-                    onClick={() => handleDeletePost(post.id)}
-                    className="border border-red-200 bg-white font-heading font-bold text-red-700 hover:bg-red-50 disabled:cursor-not-allowed disabled:opacity-60"
-                  >
-                    <Trash2 className="mr-2 h-4 w-4" />
-                    Delete Post
-                  </Button>
-                </div>
-              </article>
-            );
-          })}
-        </div>
-      )}
-    </section>
+    </>
   );
 }

--- a/frontend/src/components/post-card.tsx
+++ b/frontend/src/components/post-card.tsx
@@ -64,13 +64,7 @@ export default function PostCard({
           </div>
 
           <div className="flex flex-col items-end gap-2">
-            <Badge
-              className={
-                isLost
-                  ? "bg-[#C8102E] text-white"
-                  : "bg-green-600 text-white"
-              }
-            >
+            <Badge className="bg-[#C8102E] text-white">
               {isLost ? "Lost" : "Found"}
             </Badge>
 


### PR DESCRIPTION
## Summary

Improved the frontend and item management flow by adding account related pages, user post management, edit functionality,and better home page/sidebar UX.

## Changes

- Added `/about` page with project overview and app feature summary.
- Added `/account` page for signed in users.
- Added a **My Posts** section where users can manage their own item posts.
- Added ability for users to:
  - View their own posts
  - Mark posts as returned or active
  - Delete their own posts
  - Edit post details through a popup 
- Expanded the item update endpoint so item owners can update more fields, not only returned status.
- Hide returned posts from the public home feed so only active items appear.
- Made the filters sidebar sticky while scrolling.
- Improved the messages panel:
  - Made it sticky on the home page
  - Added close behavior for active conversations
  - Added smooth chat open animation
  - Reorganized the active chat and conversation list layout
  
