### PR TITLE
feat: UI polish, dark mode, SDSU image backgrounds, and forgot-password

### DIFF
--- a/backend/src/app/repository/user.py
+++ b/backend/src/app/repository/user.py
@@ -84,6 +84,24 @@ class UserRepository:
         return db_user
 
     @staticmethod
+    def update_password(db: Session, db_user: User, hashed_password: str) -> User:
+        """
+        Update a user's password hash.
+
+        Args:
+            db: Database session
+            db_user: User instance to update
+            hashed_password: New bcrypt hash
+
+        Returns:
+            User: Updated user
+        """
+        db_user.password_hash = hashed_password
+        db.commit()
+        db.refresh(db_user)
+        return db_user
+
+    @staticmethod
     def delete(db: Session, db_user: User) -> None:
         """
         Delete user.

--- a/backend/src/app/routes/user.py
+++ b/backend/src/app/routes/user.py
@@ -7,7 +7,10 @@ from sqlalchemy.orm import Session
 from app.core.db import get_db
 from app.schemas.token import TokenPairResponse
 from app.schemas.user import (
+    ForgotPasswordRequest,
+    ForgotPasswordResponse,
     LoginRequest,
+    ResetPasswordRequest,
     SignupResponse,
     SuccessResponse,
     User,
@@ -41,6 +44,28 @@ def login(body: LoginRequest, db: DB):
     """
     _, user_id = UserService.login(db, body.email, body.password)
     return TokenService.issue_token_pair(db, user_id)
+
+
+# POST /user/forgot-password
+@api_router.post("/forgot-password", response_model=ForgotPasswordResponse)
+def forgot_password(body: ForgotPasswordRequest, db: DB):
+    """
+    Generate a password-reset token for the given SDSU email.
+    Returns the token directly (demo mode — production would email it).
+    """
+    reset_token = UserService.forgot_password(db, body.email)
+    return ForgotPasswordResponse(
+        reset_token=reset_token,
+        message="Reset token generated. Use it within 30 minutes.",
+    )
+
+
+# POST /user/reset-password
+@api_router.post("/reset-password", response_model=SuccessResponse)
+def reset_password(body: ResetPasswordRequest, db: DB):
+    """Consume a password-reset token and set a new password."""
+    UserService.reset_password(db, body.token, body.new_password)
+    return SuccessResponse()
 
 
 # GET /user/{id}

--- a/backend/src/app/schemas/user.py
+++ b/backend/src/app/schemas/user.py
@@ -123,3 +123,33 @@ class SuccessResponse(BaseModel):
     """Schema for generic success response."""
 
     success: bool = True
+
+
+class ForgotPasswordRequest(UserBase):
+    """Schema for forgot password request — reuses SDSU email validation."""
+    pass
+
+
+class ResetPasswordRequest(BaseModel):
+    """Schema for reset password request."""
+
+    token: str
+    new_password: str = Field(..., min_length=8, max_length=20)
+
+    @field_validator("new_password")
+    @classmethod
+    def password_must_be_valid(cls, password: str) -> str:
+        if not re.search(r"[0-9]", password):
+            raise ValueError("Password must include at least 1 number")
+        if not re.search(r"[a-zA-Z]", password):
+            raise ValueError("Password must include at least 1 letter")
+        if not re.search(r'[!@#$%^&*(),.?":{}|<>]', password):
+            raise ValueError("Password must include at least 1 special character")
+        return password
+
+
+class ForgotPasswordResponse(BaseModel):
+    """Schema for forgot password response (returns token for demo use)."""
+
+    reset_token: str
+    message: str

--- a/backend/src/app/services/user.py
+++ b/backend/src/app/services/user.py
@@ -13,6 +13,7 @@ from app.core.auth import (
     create_access_token,
     get_password_hash,
     verify_password,
+    verify_token,
 )
 from app.models.user import User
 from app.repository.user import UserRepository
@@ -138,6 +139,58 @@ class UserService:
             user.last_name = body.last_name
 
         return UserRepository.update(db, user)
+
+    @staticmethod
+    def forgot_password(db: Session, email: str) -> str:
+        """
+        Generate a 30-minute password-reset JWT for the given email.
+
+        Returns:
+            str: Signed JWT with scope "password_reset"
+
+        Raises:
+            HTTPException 404: If no account exists for that email
+        """
+        user = UserRepository.get_by_email(db, email)
+        if not user:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="No account found with that email.",
+            )
+        return create_access_token(
+            data={"sub": str(user.id), "scope": "password_reset"},
+            expires_delta=timedelta(minutes=30),
+        )
+
+    @staticmethod
+    def reset_password(db: Session, token: str, new_password: str) -> None:
+        """
+        Validate a password-reset token and update the user's password.
+
+        Raises:
+            HTTPException 400: If the token is invalid, expired, or wrong scope
+            HTTPException 404: If the user referenced by the token no longer exists
+        """
+        payload = verify_token(token)
+        if not payload or payload.get("scope") != "password_reset":
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Invalid or expired reset token.",
+            )
+        try:
+            user_id = int(payload["sub"])
+        except (KeyError, TypeError, ValueError):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Invalid reset token.",
+            )
+        user = UserRepository.get_by_id(db, user_id)
+        if not user:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="User not found.",
+            )
+        UserRepository.update_password(db, user, get_password_hash(new_password))
 
     @staticmethod
     def delete_user(db: Session, user_id: int) -> None:

--- a/frontend/src/app/forgot-password/page.tsx
+++ b/frontend/src/app/forgot-password/page.tsx
@@ -1,0 +1,188 @@
+"use client";
+
+import { FormEvent, useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import Navbar from "@/components/navbar";
+import { Button } from "@/components/ui/button";
+import { apiFetch, getApiErrorMessage } from "@/lib/api";
+
+type ForgotPasswordResponse = {
+  reset_token: string;
+  message: string;
+};
+
+export default function ForgotPasswordPage() {
+  const router = useRouter();
+
+  const [message, setMessage] = useState("");
+  const [isError, setIsError] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [resetToken, setResetToken] = useState<string | null>(null);
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+
+    setMessage("");
+    setIsError(false);
+    setIsSubmitting(true);
+
+    const formData = new FormData(event.currentTarget);
+    const email = String(formData.get("email") || "").trim().toLowerCase();
+
+    if (!email) {
+      setIsError(true);
+      setMessage("Please enter your SDSU email address.");
+      setIsSubmitting(false);
+      return;
+    }
+
+    try {
+      const data = await apiFetch<ForgotPasswordResponse>(
+        "/api/v1/user/forgot-password",
+        {
+          method: "POST",
+          body: JSON.stringify({ email }),
+        },
+      );
+      setResetToken(data.reset_token);
+      setIsError(false);
+      setMessage("Reset link generated. Click below to set your new password.");
+    } catch (error) {
+      setIsError(true);
+      setMessage(getApiErrorMessage(error));
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  return (
+    <main className="min-h-screen bg-white text-black dark:bg-gray-900 dark:text-white">
+      <Navbar />
+
+      <section className="bg-[#f4f4f4] px-6 py-20 dark:bg-gray-800 md:px-16">
+        <div className="mx-auto max-w-5xl">
+          <h1 className="font-heading text-5xl font-semibold tracking-tight md:text-6xl">
+            Forgot Password
+          </h1>
+
+          <div className="mt-6 h-[2px] w-28 bg-[#C8102E]" />
+
+          <p className="mt-8 max-w-2xl text-xl leading-8 text-gray-700 dark:text-gray-300">
+            Enter your SDSU email address and we&apos;ll generate a password
+            reset link for you.
+          </p>
+        </div>
+      </section>
+
+      <section className="px-6 py-16 md:px-16">
+        <div className="mx-auto grid max-w-5xl items-start gap-10 md:grid-cols-[1fr_430px]">
+          <div>
+            <h2 className="font-heading text-3xl font-semibold text-gray-900 dark:text-gray-100">
+              Reset Your Password
+            </h2>
+
+            <p className="mt-5 text-lg leading-8 text-gray-700 dark:text-gray-300">
+              Use a valid SDSU email address associated with your account. The
+              reset link expires in 30 minutes.
+            </p>
+
+            <div className="mt-8 space-y-4 text-gray-700 dark:text-gray-300">
+              <p>
+                <span className="font-semibold text-[#C8102E]">•</span> You
+                must have an existing SDSU Lost &amp; Found account.
+              </p>
+
+              <p>
+                <span className="font-semibold text-[#C8102E]">•</span> The
+                reset link is valid for 30 minutes.
+              </p>
+
+              <p>
+                <span className="font-semibold text-[#C8102E]">•</span> Your
+                new password must meet the original security requirements.
+              </p>
+            </div>
+          </div>
+
+          <div className="rounded-xl border border-gray-200 bg-white p-8 shadow-sm dark:border-gray-700 dark:bg-gray-800">
+            <h2 className="font-heading text-2xl font-bold text-gray-900 dark:text-gray-100">
+              Password Reset
+            </h2>
+
+            {!resetToken ? (
+              <form onSubmit={handleSubmit} className="mt-8 space-y-5">
+                <div>
+                  <label
+                    htmlFor="email"
+                    className="block font-heading text-sm font-semibold text-gray-800 dark:text-gray-200"
+                  >
+                    SDSU Email
+                  </label>
+
+                  <input
+                    id="email"
+                    name="email"
+                    type="email"
+                    placeholder="name@sdsu.edu"
+                    className="mt-2 w-full rounded-md border border-gray-300 bg-white px-4 py-3 text-gray-900 outline-none focus:border-[#C8102E] focus:ring-2 focus:ring-[#C8102E]/20 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 dark:placeholder-gray-400"
+                  />
+                </div>
+
+                {message && (
+                  <p
+                    className={`rounded-md px-4 py-3 text-sm ${
+                      isError
+                        ? "bg-red-50 text-red-800"
+                        : "bg-green-50 text-green-800"
+                    }`}
+                  >
+                    {message}
+                  </p>
+                )}
+
+                <Button
+                  type="submit"
+                  disabled={isSubmitting}
+                  className="w-full bg-[#C8102E] py-6 font-heading text-base font-bold text-white hover:bg-[#a00d24]"
+                >
+                  {isSubmitting ? "Generating Link..." : "Generate Reset Link"}
+                </Button>
+              </form>
+            ) : (
+              <div className="mt-8 space-y-5">
+                <p className="rounded-md bg-green-50 px-4 py-3 text-sm text-green-800">
+                  {message}
+                </p>
+
+                <Button
+                  type="button"
+                  onClick={() =>
+                    router.push(`/reset-password?token=${encodeURIComponent(resetToken)}`)
+                  }
+                  className="w-full bg-[#C8102E] py-6 font-heading text-base font-bold text-white hover:bg-[#a00d24]"
+                >
+                  Reset My Password →
+                </Button>
+
+                <p className="text-center text-xs text-gray-500 dark:text-gray-400">
+                  This link expires in 30 minutes.
+                </p>
+              </div>
+            )}
+
+            <p className="mt-6 text-center text-sm text-gray-600 dark:text-gray-300">
+              Remembered your password?{" "}
+              <Link
+                href="/login"
+                className="font-heading font-semibold text-[#C8102E] hover:underline"
+              >
+                Sign In
+              </Link>
+            </p>
+          </div>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -86,37 +86,44 @@
 }
 
 .dark {
-  --background: oklch(0.145 0 0);
+  --background: oklch(0.085 0 0);
   --foreground: oklch(0.985 0 0);
-  --card: oklch(0.205 0 0);
+  --card: oklch(0.12 0.005 240);
   --card-foreground: oklch(0.985 0 0);
-  --popover: oklch(0.205 0 0);
+  --popover: oklch(0.12 0.005 240);
   --popover-foreground: oklch(0.985 0 0);
   --primary: oklch(0.922 0 0);
-  --primary-foreground: oklch(0.205 0 0);
-  --secondary: oklch(0.269 0 0);
+  --primary-foreground: oklch(0.12 0.005 240);
+  --secondary: oklch(0.165 0.006 240);
   --secondary-foreground: oklch(0.985 0 0);
-  --muted: oklch(0.269 0 0);
-  --muted-foreground: oklch(0.708 0 0);
-  --accent: oklch(0.269 0 0);
+  --muted: oklch(0.165 0.006 240);
+  --muted-foreground: oklch(0.65 0 0);
+  --accent: oklch(0.165 0.006 240);
   --accent-foreground: oklch(0.985 0 0);
   --destructive: oklch(0.704 0.191 22.216);
-  --border: oklch(1 0 0 / 10%);
-  --input: oklch(1 0 0 / 15%);
-  --ring: oklch(0.556 0 0);
+  --border: oklch(1 0 0 / 8%);
+  --input: oklch(1 0 0 / 12%);
+  --ring: oklch(0.45 0 0);
   --chart-1: oklch(0.87 0 0);
   --chart-2: oklch(0.556 0 0);
   --chart-3: oklch(0.439 0 0);
   --chart-4: oklch(0.371 0 0);
   --chart-5: oklch(0.269 0 0);
-  --sidebar: oklch(0.205 0 0);
+  --sidebar: oklch(0.12 0.005 240);
   --sidebar-foreground: oklch(0.985 0 0);
   --sidebar-primary: oklch(0.488 0.243 264.376);
   --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.269 0 0);
+  --sidebar-accent: oklch(0.165 0.006 240);
   --sidebar-accent-foreground: oklch(0.985 0 0);
-  --sidebar-border: oklch(1 0 0 / 10%);
-  --sidebar-ring: oklch(0.556 0 0);
+  --sidebar-border: oklch(1 0 0 / 8%);
+  --sidebar-ring: oklch(0.45 0 0);
+
+  /* Override Tailwind's gray scale in dark mode for deeper, darker tones */
+  --color-gray-950: #020408;
+  --color-gray-900: #06080e;
+  --color-gray-800: #0c1220;
+  --color-gray-700: #162032;
+  --color-gray-600: #1e2b3e;
 }
 
 .modal-scrollbar {

--- a/frontend/src/app/home/page.tsx
+++ b/frontend/src/app/home/page.tsx
@@ -155,7 +155,7 @@ export default function Home() {
       <Navbar />
 
       {/* Search Bar */}
-      <div className="mx-auto max-w-7xl px-4 pb-2 pt-5">
+      <div className="px-4 pb-2 pt-5 sm:px-6">
         <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
           <div className="relative flex-1">
             <Search className="absolute left-3 top-2.5 h-4 w-4 text-gray-400 dark:text-gray-500" />
@@ -177,7 +177,7 @@ export default function Home() {
       </div>
 
       {/* Main 3-column layout */}
-      <div className="mx-auto grid max-w-7xl grid-cols-1 gap-6 px-4 py-4 lg:grid-cols-[220px_minmax(0,1fr)_390px]">
+      <div className="grid grid-cols-1 gap-6 px-4 py-4 sm:px-6 lg:grid-cols-[220px_minmax(0,1fr)_390px]">
         {/* Left — Filters */}
         <aside className="h-fit rounded-lg border border-gray-200 bg-white p-5 shadow-sm dark:border-gray-700 dark:bg-gray-800 lg:sticky lg:top-6 lg:self-start">
           <h2 className="mb-4 font-heading text-sm font-bold uppercase tracking-wide text-gray-800 dark:text-gray-200">

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -208,7 +208,16 @@ function LoginContent() {
               </Button>
             </form>
 
-            <p className="mt-6 text-center text-sm text-gray-600 dark:text-gray-300">
+            <p className="mt-4 text-center text-sm text-gray-600 dark:text-gray-300">
+              <Link
+                href="/forgot-password"
+                className="font-heading font-semibold text-[#C8102E] hover:underline"
+              >
+                Forgot your password?
+              </Link>
+            </p>
+
+            <p className="mt-3 text-center text-sm text-gray-600 dark:text-gray-300">
               Don&apos;t have an account?{" "}
               <Link
                 href="/create-account"

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import Navbar from "@/components/navbar";
 import { Button } from "@/components/ui/button";
 import { apiFetch } from "@/lib/api";
@@ -26,6 +27,18 @@ type ItemPost = {
   created_at: string;
 };
 
+function makePatternBg(bgColor: string, textColor: string) {
+  const svg = `<svg xmlns='http://www.w3.org/2000/svg' width='1200' height='80'><text x='0' y='62' font-family='Arial Black,Arial,sans-serif' font-size='54' font-weight='900' letter-spacing='4' fill='${textColor}'>SAN DIEGO STATE UNIVERSITY</text></svg>`;
+  return {
+    backgroundColor: bgColor,
+    backgroundImage: `url("data:image/svg+xml,${encodeURIComponent(svg)}")`,
+    backgroundRepeat: "repeat" as const,
+  };
+}
+
+const lightPatternBg = makePatternBg("#C8102E", "#a50d24");
+const darkPatternBg = makePatternBg("#0a0a0a", "#242424");
+
 function formatDate(date: string) {
   return new Intl.DateTimeFormat("en-US", {
     month: "short",
@@ -34,8 +47,21 @@ function formatDate(date: string) {
 }
 
 export default function WelcomePage() {
+  const router = useRouter();
   const [recentPosts, setRecentPosts] = useState<ItemPost[]>([]);
   const [isLoadingRecentPosts, setIsLoadingRecentPosts] = useState(true);
+
+  function handleMessageAboutItem(ownerUserId: number) {
+    const token = localStorage.getItem("token");
+    const storedUserId = localStorage.getItem("userId");
+    const currentUserId = storedUserId ? Number(storedUserId) : null;
+    if (!token) {
+      router.push("/login?message=signin-required-message&redirect=/home");
+      return;
+    }
+    if (currentUserId === ownerUserId) return;
+    router.push("/home");
+  }
 
   useEffect(() => {
     async function loadRecentPosts() {
@@ -153,19 +179,19 @@ export default function WelcomePage() {
                         key={post.id}
                         className="rounded-xl border border-gray-200 bg-white p-4 dark:border-gray-700 dark:bg-gray-800"
                       >
-                        {index === 0 && post.image_url && (
-                          <div className="mb-3 h-28 overflow-hidden rounded-lg bg-gray-200 dark:bg-gray-700">
-                            {/* eslint-disable-next-line @next/next/no-img-element */}
-                            <img
-                              src={post.image_url}
-                              alt={post.title}
-                              className="h-full w-full object-cover"
-                            />
+                        {index === 0 && (
+                          <div className="relative mb-3 h-28 overflow-hidden rounded-lg">
+                            <div className="absolute inset-0 dark:hidden" style={lightPatternBg} />
+                            <div className="absolute inset-0 hidden dark:block" style={darkPatternBg} />
+                            {post.image_url && (
+                              // eslint-disable-next-line @next/next/no-img-element
+                              <img
+                                src={post.image_url}
+                                alt={post.title}
+                                className="relative z-10 h-full w-full object-contain"
+                              />
+                            )}
                           </div>
-                        )}
-
-                        {index === 0 && !post.image_url && (
-                          <div className="mb-3 h-28 rounded-lg bg-gray-200 dark:bg-gray-700" />
                         )}
 
                         <div className="flex items-start justify-between gap-3">
@@ -190,6 +216,15 @@ export default function WelcomePage() {
                             {isLost ? "Lost" : "Found"}
                           </span>
                         </div>
+
+                        <button
+                          type="button"
+                          onClick={() => handleMessageAboutItem(post.user_id)}
+                          className="mt-3 flex w-full items-center justify-center gap-2 rounded-lg bg-[#C8102E] px-4 py-2 font-heading text-sm font-bold text-white transition-all hover:-translate-y-px hover:bg-[#a00d24] hover:shadow-md active:translate-y-0 active:shadow-sm"
+                        >
+                          <MessageCircle size={14} />
+                          Message About Item
+                        </button>
                       </div>
                     );
                   })}

--- a/frontend/src/app/reset-password/page.tsx
+++ b/frontend/src/app/reset-password/page.tsx
@@ -1,0 +1,216 @@
+"use client";
+
+import { FormEvent, Suspense, useState } from "react";
+import { useSearchParams } from "next/navigation";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import Navbar from "@/components/navbar";
+import { Button } from "@/components/ui/button";
+import { apiFetch, getApiErrorMessage } from "@/lib/api";
+
+function ResetPasswordContent() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const tokenFromUrl = searchParams.get("token") ?? "";
+
+  const [message, setMessage] = useState("");
+  const [isError, setIsError] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [succeeded, setSucceeded] = useState(false);
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+
+    setMessage("");
+    setIsError(false);
+    setIsSubmitting(true);
+
+    const formData = new FormData(event.currentTarget);
+    const newPassword = String(formData.get("new_password") || "");
+    const confirmPassword = String(formData.get("confirm_password") || "");
+
+    if (!newPassword || !confirmPassword) {
+      setIsError(true);
+      setMessage("Please fill in both password fields.");
+      setIsSubmitting(false);
+      return;
+    }
+
+    if (newPassword !== confirmPassword) {
+      setIsError(true);
+      setMessage("Passwords do not match.");
+      setIsSubmitting(false);
+      return;
+    }
+
+    if (!tokenFromUrl) {
+      setIsError(true);
+      setMessage(
+        "Missing reset token. Please use the link from the forgot-password page.",
+      );
+      setIsSubmitting(false);
+      return;
+    }
+
+    try {
+      await apiFetch("/api/v1/user/reset-password", {
+        method: "POST",
+        body: JSON.stringify({ token: tokenFromUrl, new_password: newPassword }),
+      });
+      setSucceeded(true);
+      setIsError(false);
+      setMessage("Password reset successfully! Redirecting to sign in...");
+      setTimeout(() => router.push("/login"), 2000);
+    } catch (error) {
+      setIsError(true);
+      setMessage(getApiErrorMessage(error));
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  return (
+    <main className="min-h-screen bg-white text-black dark:bg-gray-900 dark:text-white">
+      <Navbar />
+
+      <section className="bg-[#f4f4f4] px-6 py-20 dark:bg-gray-800 md:px-16">
+        <div className="mx-auto max-w-5xl">
+          <h1 className="font-heading text-5xl font-semibold tracking-tight md:text-6xl">
+            Reset Password
+          </h1>
+
+          <div className="mt-6 h-[2px] w-28 bg-[#C8102E]" />
+
+          <p className="mt-8 max-w-2xl text-xl leading-8 text-gray-700 dark:text-gray-300">
+            Choose a new password for your SDSU Lost &amp; Found account.
+          </p>
+        </div>
+      </section>
+
+      <section className="px-6 py-16 md:px-16">
+        <div className="mx-auto grid max-w-5xl items-start gap-10 md:grid-cols-[1fr_430px]">
+          <div>
+            <h2 className="font-heading text-3xl font-semibold text-gray-900 dark:text-gray-100">
+              Create New Password
+            </h2>
+
+            <p className="mt-5 text-lg leading-8 text-gray-700 dark:text-gray-300">
+              Your new password must meet the following requirements.
+            </p>
+
+            <div className="mt-8 space-y-4 text-gray-700 dark:text-gray-300">
+              <p>
+                <span className="font-semibold text-[#C8102E]">•</span> 8–20
+                characters long.
+              </p>
+
+              <p>
+                <span className="font-semibold text-[#C8102E]">•</span> At
+                least one letter and one number.
+              </p>
+
+              <p>
+                <span className="font-semibold text-[#C8102E]">•</span> At
+                least one special character (e.g. !@#$%).
+              </p>
+            </div>
+          </div>
+
+          <div className="rounded-xl border border-gray-200 bg-white p-8 shadow-sm dark:border-gray-700 dark:bg-gray-800">
+            <h2 className="font-heading text-2xl font-bold text-gray-900 dark:text-gray-100">
+              New Password
+            </h2>
+
+            {succeeded ? (
+              <div className="mt-8 space-y-5">
+                <p className="rounded-md bg-green-50 px-4 py-3 text-sm text-green-800">
+                  {message}
+                </p>
+
+                <Link href="/login">
+                  <Button className="w-full bg-[#C8102E] py-6 font-heading text-base font-bold text-white hover:bg-[#a00d24]">
+                    Go to Sign In
+                  </Button>
+                </Link>
+              </div>
+            ) : (
+              <form onSubmit={handleSubmit} className="mt-8 space-y-5">
+                <div>
+                  <label
+                    htmlFor="new_password"
+                    className="block font-heading text-sm font-semibold text-gray-800 dark:text-gray-200"
+                  >
+                    New Password
+                  </label>
+
+                  <input
+                    id="new_password"
+                    name="new_password"
+                    type="password"
+                    placeholder="Enter new password"
+                    className="mt-2 w-full rounded-md border border-gray-300 bg-white px-4 py-3 text-gray-900 outline-none focus:border-[#C8102E] focus:ring-2 focus:ring-[#C8102E]/20 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 dark:placeholder-gray-400"
+                  />
+                </div>
+
+                <div>
+                  <label
+                    htmlFor="confirm_password"
+                    className="block font-heading text-sm font-semibold text-gray-800 dark:text-gray-200"
+                  >
+                    Confirm New Password
+                  </label>
+
+                  <input
+                    id="confirm_password"
+                    name="confirm_password"
+                    type="password"
+                    placeholder="Confirm new password"
+                    className="mt-2 w-full rounded-md border border-gray-300 bg-white px-4 py-3 text-gray-900 outline-none focus:border-[#C8102E] focus:ring-2 focus:ring-[#C8102E]/20 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 dark:placeholder-gray-400"
+                  />
+                </div>
+
+                {message && (
+                  <p
+                    className={`rounded-md px-4 py-3 text-sm ${
+                      isError
+                        ? "bg-red-50 text-red-800"
+                        : "bg-green-50 text-green-800"
+                    }`}
+                  >
+                    {message}
+                  </p>
+                )}
+
+                <Button
+                  type="submit"
+                  disabled={isSubmitting}
+                  className="w-full bg-[#C8102E] py-6 font-heading text-base font-bold text-white hover:bg-[#a00d24]"
+                >
+                  {isSubmitting ? "Resetting..." : "Reset Password"}
+                </Button>
+              </form>
+            )}
+
+            <p className="mt-6 text-center text-sm text-gray-600 dark:text-gray-300">
+              Back to{" "}
+              <Link
+                href="/login"
+                className="font-heading font-semibold text-[#C8102E] hover:underline"
+              >
+                Sign In
+              </Link>
+            </p>
+          </div>
+        </div>
+      </section>
+    </main>
+  );
+}
+
+export default function ResetPasswordPage() {
+  return (
+    <Suspense>
+      <ResetPasswordContent />
+    </Suspense>
+  );
+}

--- a/frontend/src/components/navbar.tsx
+++ b/frontend/src/components/navbar.tsx
@@ -58,11 +58,11 @@ export default function Navbar() {
 
   return (
     <nav className="w-full border-b border-gray-200 bg-white shadow-sm dark:border-gray-700 dark:bg-gray-900">
-      <div className="mx-auto flex h-20 max-w-7xl items-center justify-between px-4 md:px-6">
+      <div className="flex h-20 w-full items-center justify-between px-4 md:px-6">
         {/* Logo */}      
         <Link
           href="/"
-          className="flex h-14 w-[300px] shrink-0 items-center overflow-hidden"
+          className="flex h-16 w-[360px] shrink-0 items-center overflow-hidden"
         >
           {/* Dark logo for light mode */}
           <Image
@@ -71,7 +71,7 @@ export default function Navbar() {
             width={900}
             height={300}
             priority
-            className="block w-[250px] max-w-none object-contain dark:hidden"
+            className="block w-[320px] max-w-none object-contain dark:hidden"
           />
 
           {/* Light logo for dark mode */}
@@ -81,7 +81,7 @@ export default function Navbar() {
             width={900}
             height={300}
             priority
-            className="hidden w-[250px] max-w-none object-contain dark:block"
+            className="hidden w-[320px] max-w-none object-contain dark:block"
           />
         </Link>
 
@@ -89,14 +89,14 @@ export default function Navbar() {
         <div className="flex items-center gap-1 font-heading text-sm font-semibold sm:gap-3">
           <Link
             href="/home"
-            className="hidden rounded-md px-2 py-1 text-gray-700 transition-colors hover:text-[#C8102E] dark:text-gray-200 dark:hover:text-[#e84060] sm:inline"
+            className="hidden rounded-md px-2 py-1 text-gray-700 transition-all hover:bg-gray-100 hover:text-[#C8102E] dark:text-gray-200 dark:hover:bg-gray-800 dark:hover:text-[#e84060] sm:inline"
           >
             Browse Items
           </Link>
 
           <Link
             href="/about"
-            className="hidden rounded-md px-2 py-1 text-gray-700 transition-colors hover:text-[#C8102E] dark:text-gray-200 dark:hover:text-[#e84060] md:inline"
+            className="hidden rounded-md px-2 py-1 text-gray-700 transition-all hover:bg-gray-100 hover:text-[#C8102E] dark:text-gray-200 dark:hover:bg-gray-800 dark:hover:text-[#e84060] md:inline"
           >
             About
           </Link>
@@ -105,14 +105,14 @@ export default function Navbar() {
             <>
               <Link
                 href="/account"
-                className="hidden rounded-md px-2 py-1 text-gray-700 transition-colors hover:text-[#C8102E] dark:text-gray-200 dark:hover:text-[#e84060] sm:inline"
+                className="hidden rounded-md px-2 py-1 text-gray-700 transition-all hover:bg-gray-100 hover:text-[#C8102E] dark:text-gray-200 dark:hover:bg-gray-800 dark:hover:text-[#e84060] sm:inline"
               >
                 My Account
               </Link>
 
               <button
                 onClick={handleSignOut}
-                className="rounded-md bg-[#C8102E] px-3 py-1.5 font-heading font-semibold text-white transition-colors hover:bg-[#a00d24]"
+                className="rounded-md bg-[#C8102E] px-3 py-1.5 font-heading font-semibold text-white transition-all hover:-translate-y-px hover:bg-[#a00d24] hover:shadow-md active:translate-y-0 active:shadow-sm"
               >
                 Sign Out
               </button>
@@ -121,14 +121,14 @@ export default function Navbar() {
             <>
               <Link
                 href="/login"
-                className="hidden rounded-md px-2 py-1 text-gray-700 transition-colors hover:text-[#C8102E] dark:text-gray-200 dark:hover:text-[#e84060] sm:inline"
+                className="hidden rounded-md px-2 py-1 text-gray-700 transition-all hover:bg-gray-100 hover:text-[#C8102E] dark:text-gray-200 dark:hover:bg-gray-800 dark:hover:text-[#e84060] sm:inline"
               >
                 Sign In
               </Link>
 
               <Link
                 href="/create-account"
-                className="hidden items-center rounded-md bg-[#C8102E] px-3 py-1.5 text-white transition-colors hover:bg-[#a00d24] md:inline-flex"
+                className="hidden items-center rounded-md bg-[#C8102E] px-3 py-1.5 text-white transition-all hover:-translate-y-px hover:bg-[#a00d24] hover:shadow-md active:translate-y-0 active:shadow-sm md:inline-flex"
               >
                 Create Account
               </Link>

--- a/frontend/src/components/post-card.tsx
+++ b/frontend/src/components/post-card.tsx
@@ -2,6 +2,18 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { MapPin, MessageCircle } from "lucide-react";
 
+function makePatternBg(bgColor: string, textColor: string) {
+  const svg = `<svg xmlns='http://www.w3.org/2000/svg' width='1200' height='80'><text x='0' y='62' font-family='Arial Black,Arial,sans-serif' font-size='54' font-weight='900' letter-spacing='4' fill='${textColor}'>SAN DIEGO STATE UNIVERSITY</text></svg>`;
+  return {
+    backgroundColor: bgColor,
+    backgroundImage: `url("data:image/svg+xml,${encodeURIComponent(svg)}")`,
+    backgroundRepeat: "repeat" as const,
+  };
+}
+
+const lightPatternBg = makePatternBg("#C8102E", "#a50d24");
+const darkPatternBg = makePatternBg("#0a0a0a", "#242424");
+
 interface PostCardProps {
   id: number;
   user_id: number;
@@ -42,16 +54,20 @@ export default function PostCard({
 
   return (
     <article className="overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm dark:border-gray-700 dark:bg-gray-800">
-      <div className="flex h-52 items-center justify-center bg-gray-100 text-sm text-gray-400 dark:bg-gray-700 dark:text-gray-500">
+      <div className="relative flex max-h-72 items-center justify-center overflow-hidden">
+        <div className="absolute inset-0 dark:hidden" style={lightPatternBg} />
+        <div className="absolute inset-0 hidden dark:block" style={darkPatternBg} />
         {image_url ? (
           // eslint-disable-next-line @next/next/no-img-element
           <img
             src={image_url}
             alt={title}
-            className="h-full w-full object-cover"
+            className="relative z-10 max-h-72 w-full object-contain"
           />
         ) : (
-          "[ Photo will appear here ]"
+          <span className="relative z-10 py-16 text-sm text-white/60">
+            [ Photo will appear here ]
+          </span>
         )}
       </div>
 

--- a/frontend/src/components/ui/button.tsx
+++ b/frontend/src/components/ui/button.tsx
@@ -5,7 +5,7 @@ import { Slot } from "radix-ui";
 import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
-  "group/button inline-flex shrink-0 items-center justify-center rounded-lg border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  "group/button inline-flex shrink-0 items-center justify-center rounded-lg border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none hover:-translate-y-px hover:shadow-sm focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:not-aria-[haspopup]:translate-y-0 active:not-aria-[haspopup]:shadow-none disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
   {
     variants: {
       variant: {


### PR DESCRIPTION
UI / Layout
- Remove max-w-7xl from home page search bar and grid — layout now fills the full viewport width at any resolution
- Navbar inner wrapper made full-width (removed max-w-7xl); logo container and image sizes enlarged for better legibility
- Added hover:bg pill highlight on nav text links and hover lift + shadow on all solid red buttons
- Shared Button component: hover:-translate-y-px + shadow-sm, improved active state (translate-y-0, shadow-none)

Image display
- Switch post-card image container from fixed h-52 object-cover (caused distortion) to max-h-72 object-contain
- Fill letterbox space with branded SDSU repeating-text background: red pattern in light mode, dark pattern in night mode
- Apply the same fix to the welcome page live-feed preview cards

Welcome page
- Fixed live-feed images using same object-contain + pattern-background technique
- Added "Message About Item" button to each live-feed card; unauthenticated users are redirected to /login, same-owner clicks are silently ignored, authenticated users are routed to /home (where the full ConversationPanel lives)

Dark mode
- Significantly darken the dark-mode gray palette via CSS variable overrides inside .dark in globals.css (gray-600 through gray-950 remapped to deep navy-black tones)
- Updated CSS custom properties (--background, --card, --secondary, --muted, --accent, etc.) for a cohesive deep dark theme

Forgot / Reset password
- Backend: new POST /api/v1/user/forgot-password and POST /api/v1/user/reset-password endpoints
- Uses a signed 30-minute JWT with scope "password_reset" (no extra DB table needed)
- New schemas: ForgotPasswordRequest, ResetPasswordRequest, ForgotPasswordResponse
- UserRepository.update_password helper; UserService.forgot_password / reset_password methods
- Frontend: /forgot-password page (email form → displays reset link on success)
- Frontend: /reset-password?token=... page (new-password + confirm form, auto-redirects to /login on success)
- Login page: "Forgot your password?" link added below the Sign In button